### PR TITLE
[WIP] Synchronous temporal filter workflow

### DIFF
--- a/niworkflows/func/__init__.py
+++ b/niworkflows/func/__init__.py
@@ -2,3 +2,4 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import absolute_import, division, print_function, unicode_literals
+from .filter import init_temporal_filter_wf

--- a/niworkflows/func/filter.py
+++ b/niworkflows/func/filter.py
@@ -21,6 +21,7 @@ from ..interfaces.filter import (
     RestoreNaN
 )
 
+
 def init_temporal_filter_wf(t_rep,
                             detrend=True,
                             interpolate=True,
@@ -317,7 +318,7 @@ def _get_fsl_passband(passband, sampling_rate):
     For use when filtering with a Gaussian kernel.
     1) Convert the cutoff frequencies from Hz (cycles per second) to cycles
        per repetition.
-    2) Convert from frequency cutoff (in Hz) to cycle cutoff (in s). 
+    2) Convert from frequency cutoff (in Hz) to cycle cutoff (in s).
     3) Then, determine how many cycles of the cutoff per repetition.
 
     Parameters

--- a/niworkflows/func/filter.py
+++ b/niworkflows/func/filter.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+
+"""
+Temporal filtering operations for the image processing system
+"""
+
+from multiprocessing import cpu_count
+from nipype.pipeline import engine as pe
+from nipype.interfaces import utility as niu, fsl, afni
+from ..interfaces.filter import (
+    TemporalFilter4D, TemporalFilter2D,
+    Interpolate4D, Interpolate2D,
+    DemeanDetrend4D, DemeanDetrend2D
+)
+
+def init_temporal_filter_wf(t_rep,
+                            detrend=True,
+                            interpolate=True,
+                            name='temporal_filter_wf',
+                            omp_nthreads=None,
+                            mem_gb=3.0,
+                            passband=(0.01, 0.08),
+                            filter_type="butterworth",
+                            filter_order=1,
+                            detrend_order=0,
+                            ripple_pass=5,
+                            ripple_stop=20):
+    """
+    This workflow synchronously filters the principal 4-dimensional analyte
+    image and any 2-dimensional and 4-dimensional confound files.
+
+    This workflow follows the recommendations from Power et al. (2014):
+    https://www.ncbi.nlm.nih.gov/pubmed/23994314
+
+      1. Demeaning and polynomial detrending of all inputs so as to ensure a
+         well-behaved filter.
+      2. Interpolation over any frames flagged for data quality and any
+         missing (NaN or n/a) values using an approach based on the
+         Lomb-Scargle periodogram for unevenly sampled data.
+      3. Temporal filtering of all interpolated data using the user-specified
+         filter. For Gaussian and Fourier filters, this calls a subroutine to
+         process any 2-dimensional datasets.
+      4. Restoration of missing values to the dataset.
+      5. Adding back the mean from the demean/detrend step.
+
+
+    .. workflow::
+        :graph2use: orig
+        :simple_form: yes
+        from niworkflows.func import init_temporal_filter_wf
+        wf = init_temporal_filter_wf()
+
+
+    **Parameters**
+        
+        t_rep: float
+            Repetition time of all data to be filtered.
+        detrend: bool
+            Indicates whether the data should be detrended prior to filtering.
+            Detrending is required to ensure well-behaved Butterworth,
+            Chebyshev, and elliptic filters, but may be disabled for other
+            filter classes.
+        interpolate: bool
+            Indicates whether the data should be interpolated prior to
+            filtering on the basis of the provided temporal mask.
+        name : str
+            Name of workflow (default: ``temporal_filter_wf``)
+        omp_nthreads : int
+            Maximum number of threads an individual process may use
+        mem_gb : float
+            Estimated peak memory consumption of the most hungry nodes
+            in the workflow
+        passband : tuple
+            A 2-tuple of frequencies, in Hertz. The first element of the tuple
+            corresponds to the high-pass cutoff frequency for the temporal
+            filter, while the second corresponds to the low-pass cutoff
+            frequency for the temporal filter.
+            * Default behaviour implements a bandpass filter.
+            * To implement a high-pass filter, set the low-pass frequency to
+              the string value ``nyquist``.
+            * To implement a low-pass filter, set the high-pass frequency to
+              0.
+            * Butterworth, Chebyshev, and elliptic filters support bandstop
+              filters; these can be implemented by setting the high-pass
+              frequency higher than the low-pass frequency.
+        filter_type : str
+            The type of temporal filter to be applied. Valid options include
+            ``butterworth`` (default), ``fourier``, ``gaussian``,
+            ``chebyshev1``, ``chebyshev2``, and ``elliptic``.
+        filter_order : str
+            The order of the filter. Has no effect for ``gaussian`` or
+            ``fourier`` filters. In practice, the actual filter order is
+            double the order specified by the input parameter because the
+            filter is applied first forward and then backward to ensure zero
+            phase shift.
+        detrend_order: int
+            The degree of polynomial to be fit as part of the detrend
+            protocol.
+            (order 0: demean; order 1: linear; order 2: quadratic; . . .)
+        ripple_pass : str
+            The ripple in the passband. Affects only ``chebyshev1`` and
+            ``elliptic`` filters.
+        ripple_stop : str
+            The attenuation factor in the stopband. Affects only ``elliptic``
+            and ``chebyshev2`` filters.
+
+
+    **Inputs**
+        
+        timeseries_4d
+            List of 4D time series formatted as a NIfTI file.
+        timeseries_2d
+            List of 1D or 2D time series files, for instance matrices of
+            confound regressors.
+        brain_mask
+            (optional) A binary-valued NIfTI image indicating, for each voxel,
+            whether it contains brain tissue. Used to limit computation to a
+            specific region: substantially accelerates processing.
+        temporal_mask
+            (optional) A binary valued text file equal in length to the
+            temporal dimension of ``timeseries_4d`` indicating, for each time
+            point, whether it should be included in processing.
+
+
+    **Outputs**
+        
+        timeseries_4d_filtered
+            The filtered and fully processed ``timeseries_4d``.
+        timeseries_2d_filtered
+            The filtered and fully processed ``timeseries_2d``.
+
+
+    """
+    workflow = pe.Workflow(name=name)
+
+    if omp_nthreads is None or omp_nthreads < 1:
+        omp_nthreads = cpu_count()
+
+    inputnode = pe.Node(niu.IdentityInterface(
+        fields=['timeseries_4d', 'timeseries_2d',
+                'brain_mask', 'temporal_mask']),
+        name='inputnode')
+    outputnode = pe.Node(niu.IdentityInterface(
+        fields=['timeseries_4d_filtered', 'timeseries_2d_filtered']),
+        name='outputnode')
+
+    src_4d = (inputnode, 'timeseries_4d')
+    src_2d = (inputnode, 'timeseries_2d')
+    dst_4d = (outputnode, 'timeseries_4d_filtered')
+    dst_2d = (outputnode, 'timeseries_2d_filtered')
+
+    if detrend:
+        dmdt_4d = pe.MapNode(
+            DemeanDetrend4D(detrend_order=detrend_order),
+            name='dmdt_4d', iterfield=['in_file'],
+            n_procs=omp_nthreads, mem_gb=mem_gb)
+        dmdt_2d = pe.MapNode(
+            DemeanDetrend2D(detrend_order=detrend_order),
+            name='dmdt_2d', iterfield=['in_file'])
+        remean = pe.MapNode(
+            fsl.maths.BinaryMaths(operation='add'),
+            name='remean', iterfield=['in_file', 'operand_file'],
+            n_procs=omp_nthreads, mem_gb=mem_gb)
+
+        workflow.connect([
+            (inputnode, dmdt_4d, [('brain_mask', 'mask'),
+                                  ('temporal_mask', 'tmask')]),
+            (inputnode, dmdt_2d, [('temporal_mask', 'tmask')]),
+            (src_4d[0], dmdt_4d, [(src_4d[1], 'in_file')]),
+            (src_2d[0], dmdt_2d, [(src_2d[1], 'in_file')]),
+            (dmdt_4d, remean, [('output_mean', 'operand_file')]),
+            (remean, dst_4d[0], [('out_file', dst_4d[1])]),
+        ])
+        src_4d = (dmdt_4d, 'output_file')
+        src_2d = (dmdt_2d, 'output_file')
+        dst_4d = (remean, 'in_file')
+
+    if interpolate:
+        interp_4d = pe.MapNode(
+            Interpolate4D(t_rep=t_rep),
+            name='interp_4d', iterfield=['in_file'],
+            n_procs=omp_nthreads, mem_gb=mem_gb)
+        interp_2d = pe.MapNode(
+            Interpolate2D(t_rep=t_rep),
+            name='interp_2d', iterfield=['in_file'])
+
+        workflow.connect([
+            (inputnode, interp_4d, [('brain_mask', 'mask'),
+                                    ('temporal_mask', 'tmask')]),
+            (inputnode, interp_2d, [('temporal_mask', 'tmask')]),
+            (src_4d[0], interp_4d, [(src_4d[1], 'in_file')]),
+            (src_2d[0], interp_2d, [(src_2d[1], 'in_file')]),
+        ])
+        src_4d = (interp_4d, 'output_file')
+        src_2d = (interp_2d, 'output_file')
+
+    if filter_type == 'gaussian':
+        _validate_passband(filter_type, passband)
+        passband = get_fsl_passband(passband, t_rep)
+        gaussian_4d = pe.MapNode(fsl.maths.TemporalFilter(
+            highpass_sigma=passband[0],
+            lowpass_sigma=passband[1],
+            output_type='NIFTI_GZ'),
+            name='gaussian_4d', iterfield=['in_file'],
+            n_procs=omp_nthreads, mem_gb=mem_gb)
+        gaussian_2d = pe.MapNode(fsl.maths.TemporalFilter(
+            highpass_sigma=passband[0],
+            lowpass_sigma=passband[1],
+            output_type='NIFTI_GZ'),
+            name='gaussian_2d', iterfield=['in_file'],
+            n_procs=omp_nthreads, mem_gb=mem_gb)
+    elif filter_type == 'fourier':
+        _validate_passband(filter_type, passband)
+        fourier_4d = pe.MapNode(afni.Bandpass(
+            highpass=passband[0],
+            lowpass=passband[1],
+            outputtype='NIFTI_GZ'),
+            name='fourier_4d', iterfield=['in_file'],
+            n_procs=omp_nthreads, mem_gb=mem_gb)
+        fourier_2d = pe.MapNode(afni.Bandpass(
+            highpass=passband[0],
+            lowpass=passband[1],
+            outputtype='NIFTI',
+            tr=t_rep),
+            name='fourier_2d', iterfield=['in_file'],
+            n_procs=omp_nthreads, mem_gb=mem_gb)
+    else:
+        signal_4d = pe.MapNode(TemporalFilter4D(
+            t_rep=t_rep,
+            filter_type=filter_type,
+            filter_order=filter_order,
+            passband=passband,
+            ripple_pass=ripple_pass,
+            ripple_stop=ripple_stop),
+            name='signal_4d', iterfield=['in_file'],
+            n_procs=omp_nthreads, mem_gb=mem_gb)
+        signal_2d = pe.MapNode(TemporalFilter2D(
+            t_rep=t_rep,
+            filter_type=filter_type,
+            filter_order=filter_order,
+            passband=passband,
+            ripple_pass=ripple_pass,
+            ripple_stop=ripple_stop),
+            name='signal_2d', iterfield=['in_file'],
+            n_procs=omp_nthreads, mem_gb=mem_gb)
+
+        workflow.connect([
+            (inputnode, signal_4d, [('brain_mask', 'mask')]),
+            (src_4d[0], signal_4d, [(src_4d[1], 'in_file')]),
+            (src_2d[0], signal_2d, [(src_2d[1], 'in_file')]),
+        ])
+        src_4d = (signal_4d, 'output_file')
+        src_2d = (signal_2d, 'output_file')
+
+    workflow.connect([
+        (src_4d[0], dst_4d[0], [(src_4d[1], dst_4d[1])]),
+        (src_2d[0], dst_2d[0], [(src_2d[1], dst_2d[1])]),
+    ])
+    return workflow
+
+
+def _validate_passband(filter_type, passband):
+    """Verify that the filter passband is reasonably formulated.
+
+    Parameters
+    ----------
+    filter_type: str
+        String indicating the type of filter.
+    passband: tuple
+        2-tuple indicating high-pass and low-pass cutoffs for the filter.
+    """
+    if passband[0] > passband[1]:
+        raise ValueError(
+            '\n'
+            'High-pass cutoff must be less than low-pass cutoff\n'
+            'for the selected filter type.\n'
+            '==================================================\n'
+            'Filter class:     {0}\n'
+            'High-pass cutoff: {1[0]}\n'
+            'Low-pass cutoff:  {1[1]}\n'.format(filter_type, passband))
+
+
+def _get_fsl_passband(passband, sampling_rate):
+    """
+    Convert the passband to a form that FSL can understand.
+    For use when filtering with a Gaussian kernel.
+    1) Convert the cutoff frequencies from Hz (cycles per second) to cycles
+       per repetition.
+    2) Convert from frequency cutoff (in Hz) to cycle cutoff (in s). 
+    3) Then, determine how many cycles of the cutoff per repetition.
+
+    Parameters
+    ----------
+    passband: tuple
+        2-tuple indicating high-pass and low-pass cutoffs for the filter.
+    sampling_rate: float
+        Repetition time.
+
+    Returns
+    -------
+    tuple
+        FSL-compatible passband.
+    """
+    passband_frequency = (0, -1)
+    passband_frequency[0] = (1/passband[0])/(2 * sampling_rate)
+    if passband[1] == 'nyquist':
+        passband_frequency[1] = -1
+    else:
+        passband_frequency[1] = 1/passband[1]/(2 * sampling_rate)
+    return passband_frequency

--- a/niworkflows/func/filter.py
+++ b/niworkflows/func/filter.py
@@ -59,7 +59,7 @@ def init_temporal_filter_wf(t_rep,
 
 
     **Parameters**
-        
+
         t_rep: float
             Repetition time of all data to be filtered.
         detrend: bool
@@ -113,7 +113,7 @@ def init_temporal_filter_wf(t_rep,
 
 
     **Inputs**
-        
+
         timeseries_4d
             List of 4D time series formatted as a NIfTI file.
         timeseries_2d
@@ -130,7 +130,7 @@ def init_temporal_filter_wf(t_rep,
 
 
     **Outputs**
-        
+
         timeseries_4d_filtered
             The filtered and fully processed ``timeseries_4d``.
         timeseries_2d_filtered

--- a/niworkflows/func/timeseries1D.py
+++ b/niworkflows/func/timeseries1D.py
@@ -66,20 +66,16 @@ def init_apply_to_2d_wf(function_node,
         out_files
             TSV files with the requested transformation applied.
     """
-    workflow  = pe.Workflow(name=name)
-    
+    workflow = pe.Workflow(name=name)
+
     # I/O nodes
     inputnode = pe.Node(
         name='inputnode',
-        interface=niu.IdentityInterface(
-            fields=['in_files']
-    ))
+        interface=niu.IdentityInterface(fields=['in_files']))
     outputnode = pe.Node(
         name='outputnode',
-        interface=niu.IdentityInterface(
-            fields=['out_files']
-    ))
-    
+        interface=niu.IdentityInterface(fields=['out_files']))
+
     # Assemble the workflow.
     if mode == 'afni3d':
         to_1d = pe.MapNode(name='to_1d', iterfield=['in_file'],
@@ -88,12 +84,14 @@ def init_apply_to_2d_wf(function_node,
                              interface=TSVFrom1D(in_format='columns'))
         # This is extremely hackish, but it seems to be the only way to get
         # AFNI 3D operations to work on 1D files in Nipype as of now
-        suffix_1d_1 = pe.MapNode(name=('suffix_1D_first'), iterfield=['src'],
+        suffix_1d_1 = pe.MapNode(
+            name=('suffix_1D_first'), iterfield=['src'],
             interface=niu.Function(
                 input_names=['src'],
                 output_names=['real_dst'],
                 function=_copy_to_1D))
-        suffix_1d_2 = pe.MapNode(name=('suffix_1D_second'), iterfield=['src'],
+        suffix_1d_2 = pe.MapNode(
+            name=('suffix_1D_second'), iterfield=['src'],
             interface=niu.Function(
                 input_names=['src'],
                 output_names=['real_dst'],
@@ -125,12 +123,12 @@ def init_apply_to_2d_wf(function_node,
             (inputnode, tsv_to_img, [('in_files', 'in_file')]),
             (tsv_to_img, function_node, [('out_file', input_field)]),
             (tsv_to_img, copy_geometry, [('out_file', 'in_file')]),
-            (function_node, copy_geometry, [(output_field,'dest_file')]),
+            (function_node, copy_geometry, [(output_field, 'dest_file')]),
             (copy_geometry, img_to_tsv, [('out_file', 'in_file')]),
             (tsv_to_img, img_to_tsv, [('header', 'header')]),
             (img_to_tsv, outputnode, [('out_file', 'out_files')])
         ])
-    
+
     return workflow
 
 

--- a/niworkflows/func/timeseries1D.py
+++ b/niworkflows/func/timeseries1D.py
@@ -2,258 +2,139 @@
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
+
 """
-Operations to apply analytic tools designed for 4D NIfTI time series to
-2D TSV files.
+Workflows for applying image processing tools to TSV files
 """
-from nipype.utils.filemanip import fname_presuffix
-from nipype.interfaces.base import (
-    traits, TraitedSpec, BaseInterfaceInputSpec, SimpleInterface, File)
-from .filter import _unfold_image
+
+from nipype.interfaces import utility as niu, fsl
+import nipype.pipeline.engine as pe
+from ..interfaces.timeseries1D import (
+    TSVToImage, ImageToTSV, TSVFrom1D, TSVTo1D
+)
 
 
-class TSVToImageInputSpec(BaseInterfaceInputSpec):
-    in_file = File(exists=True, mandatory=True, desc='TSV file')
-    t_rep = traits.Float(mandatory=True, desc='Repetition time')
+def init_apply_to_2d_wf(function_node,
+                        t_rep,
+                        name='apply_to_2d_wf',
+                        mode=None,
+                        input_field='in_file',
+                        output_field='out_file'):
+    """
+    This workflow applies any time series processing node designed for NIfTI
+    time series processing to a TSV file. This currently only works with one-
+    to-one processing functions: those that generate a single main output from
+    a single main input.
 
 
-class TSVToImageOutputSpec(TraitedSpec):
-    out_file = File(exists=True, desc='Image derived from input TSV')
-    header = traits.CList(traits.Str, desc='Header stripped from TSV')
+    .. workflow::
+        :graph2use: orig
+        :simple_form: yes
+        from niworkflows.func import init_temporal_filter_wf
+        wf = init_temporal_filter_wf()
 
 
-class TSVToImage(SimpleInterface):
-    """Convert a TSV into an image"""
-    input_spec = TSVToImageInputSpec
-    output_spec = TSVToImageOutputSpec
+    **Parameters**
 
-    def _run_interface(self, runtime):
-        out_file = fname_presuffix(self.inputs.in_file,
-                                   suffix='_TSVToImage.nii.gz',
-                                   newpath=runtime.cwd,
-                                   use_ext=False)
-        (self._results['out_file'],
-         self._results['header']) = tsv2img(tsv=self.inputs.in_file,
-                                            img=out_file,
-                                            t_rep=self.inputs.t_rep)
-        return runtime
-
-
-class ImageToTSVInputSpec(BaseInterfaceInputSpec):
-    in_file = File(exists=True, mandatory=True, desc='NIfTI file')
-    mask = traits.Either(
-        None, File(exists=True), default=None, usedefault=True,
-        desc='NIfTI mask for TSV extraction')
-    header = traits.CList(traits.Str, desc='Header for TSV columns')
+        function_node
+            The nipype image processing node that should be applied to the
+            input one- or two-dimensional TSV file.
+        t_rep
+            Repetition time or sampling interval for the data in the TSV file.
+        name
+            Name of workflow (default: ``apply_to_2d_wf``)
+        mode
+            Either ``afni3d`` or None (default). Set to ``afni3d`` if the
+            transformation to be applied uses an interface to an AFNI ``3d~``
+            function. (This changes the architecture of the workflow.)
+        input_field
+            Input field of ``function_node`` (default ``in_file``)
+        output_field
+            Output field of ``function_node`` (default ``out_file``)
 
 
-class ImageToTSVOutputSpec(TraitedSpec):
-    out_file = File(exists=True, desc='TSV derived from input image')
+    **Inputs**
+
+        in_file
+            A one- or two-dimensional TSV file to which the processing step in
+            `function_node` should be applied.
 
 
-class ImageToTSV(SimpleInterface):
-    """Convert an image into a TSV."""
-    input_spec = ImageToTSVInputSpec
-    output_spec = ImageToTSVOutputSpec
+    **Outputs**
 
-    def _run_interface(self, runtime):
-        out_file = fname_presuffix(self.inputs.in_file,
-                                   suffix='_imageToTSV.tsv',
-                                   newpath=runtime.cwd,
-                                   use_ext=False)
-        self._results['out_file'] = img2tsv(img=self.inputs.in_file,
-                                            tsv=out_file,
-                                            mask=self.inputs.mask,
-                                            header=self.inputs.header)
-        return runtime
-
-
-class TSVTo1DInputSpec(BaseInterfaceInputSpec):
-    in_file = File(exists=True, mandatory=True, desc='TSV to transpose')
-    transpose = traits.Bool(usedefault=True, desc='Indicates whether the '
-                            'data should be transposed before saving as 1D')
-
-
-class TSVTo1DOutputSpec(TraitedSpec):
-    out_file = File(exists=True, desc='transposed TSV')
-    header = traits.CList(traits.Str, desc='header stripped from TSV')
-
-
-class TSVTo1D(SimpleInterface):
-    """Convert a TSV file to a 1D file that can be used with AFNI."""
-    input_spec = TSVTransposeInputSpec
-    output_spec = TSVTransposeOutputSpec
-
-    def _run_interface(self, runtime):
-        out_file = fname_presuffix(self.inputs.in_file,
-                                   suffix='_TSVto1D',
-                                   newpath=runtime.cwd)
-        (self._results['out_file'],
-         self._results['header']) = tsv_to_1d(tsv=self.inputs.in_file,
-                                              afni1d=out_file,
-                                              transpose=self.inputs.transpose)
-        return runtime
-
-
-class TSVFrom1DInputSpec(BaseInterfaceInputSpec):
-    in_file = File(exists=True, mandatory=True, desc='AFNI 1D file')
-    in_format = traits.Enum(
-        'columns', 'rows', usedefault=True,
-        desc='format of the 1D file (observations in `rows` or `columns`)')
-    header = traits.Either(None, traits.List, default=None, usedefault=True,
-                           desc='header to prepend to the output TSV')
-
-
-class TSVFrom1DOutputSpec(TraitedSpec):
-    out_file = File(exists=True, desc='TSV derived from input 1D file')
-
-
-class TSVFrom1D(SimpleInterface):
-    """Convert an AFNI 1D file to (potentially) BIDS-compatible TSV format."""
-    input_spec = TSVFrom1DInputSpec
-    output_spec = TSVFrom1DOutputSpec
-
-    def _run_interface(self, runtime):
-        out_file = fname_presuffix(self.inputs.in_file,
-                                   suffix='_TSVfrom1D',
-                                   newpath=runtime.cwd)
-
-        self._results['out_file'] = tsv_from_1D(afni1d=self.inputs.in_file,
-                                                tsv=out_file,
-                                                format=self.inputs.in_format,
-                                                header=self.inputs.header)
-
-        return runtime
-
-
-def tsv2img(tsv, img, t_rep):
-    """Create a dummy NIfTI image out of a tsv file, thus enabling it to be
-    processed through nodes that ordinarily only operate on valid image files.
-
-    Note that dummy NIfTIs must explicitly have repetition time set via input
-    to this function, and the affine of a dummy NIfTI is identity.
+        out_file
+            TSV file with the requested transformation applied.
+    """
+    workflow  = pe.Workflow(name=name)
     
-    Parameters
-    ----------
-    tsv: str
-        Path to the TSV file to be converted into an image.
-    img: str
-        Path where the converted file should be saved.
-    t_rep: float
-        Repetition time or sampling interval of the dataset.
+    # I/O nodes
+    inputnode = pe.Node(
+        name='inputnode',
+        interface=niu.IdentityInterface(
+            fields=['in_file']
+    ))
+    outputnode = pe.Node(
+        name='outputnode',
+        interface=niu.IdentityInterface(
+            fields=['out_file']
+    ))
+    
+    # Assemble the workflow.
+    if mode == 'afni3d':
+        to_1d = pe.Node(name='to_1d', interface=TSVTo1D(transpose=True))
+        from_1d = pe.Node(name='from_1d',
+                          interface=xcp.TSVFrom1D(in_format='columns'))
+        # This is extremely hackish, but it seems to be the only way to get
+        # AFNI 3D operations to work on 1D files in Nipype as of now
+        suffix_1d_1 = pe.Node(name=('suffix_1D_first'),
+            interface=niu.Function(
+                input_names=['src'],
+                output_names=['real_dst'],
+                function=_move_ifc))
+        suffix_1d_2 = pe.Node(name=('suffix_1D_second'),
+            interface=niu.Function(
+                input_names=['src'],
+                output_names=['real_dst'],
+                function=_move_ifc))
 
-    Returns
-    -------
-    str
-        Path to the image generated from the TSV file.
-    list
-        Column names from the TSV header, formatted as a list, so that they
-        can potentially be added later if the image is converted back.
-    """
-    tsv_data = pd.read_csv(tsv, header=None, skiprows=[0], sep='\t').values.T
-    tsv_data.shape = [tsv_data.shape[0],1,1,tsv_data.shape[1]]
-    header = list(pd.read_csv(tsv, sep='\t', nrows=0, header=0).columns)
-    img = nib.Nifti1Image(dataobj=tsv_data, affine=np.eye(4))
-    tsv_img.header['pixdim'][4] = t_rep
-    nib.save(tsv_img, img)
-    return img, header
-
-
-def img2tsv(img, tsv, mask=None, header=None):
-    """Dump data from an image file into tabular form.
-
-    Parameters
-    ----------
-    img
-        The time series image to be dumped into TSV form.
-    tsv
-        The path where the TSV should be saved.
-    mask
-        Spatial mask indicating voxels of the image to include in the TSV.
-    header
-        Header to be added to the output TSV file.
-
-    Returns
-    -------
-    str
-        Path to the TSV generated from image data.
-    """
-    img = nib.load(img)
-    img_data = _unfold_image(img, mask=mask)
-
-    if header is not None:
-        tsv_data = DataFrame(data=img_data.T, columns=header)
-        tsv_data.to_csv(tsv, sep='\t', index=False,
-                        na_rep='n/a', header=True)
+        workflow.connect([
+            (inputnode, to_1d, [('in_file', 'in_file')]),
+            (to_1d, suffix_1d_1, [('out_file', 'src')]),
+            (suffix_1d_1, function_node, [('real_dst', input_field)]),
+            (function_node, suffix_1d_2, [(output_field, 'src')]),
+            (suffix_1d_2, from_1d, [('real_dst', 'in_file')]),
+            (to_1d, from_1d, [('header', 'header')]),
+            (from_1d, outputnode, [('out_file', 'out_file')])
+        ])
     else:
-        tsv_data = DataFrame(data=img_data.T)
-        tsv_data.to_csv(tsv, sep='\t', index=False,
-                        na_rep='n/a', header=False)
-    return tsv
+        # Map tsv to image and image to tsv
+        tsv_to_img = pe.Node(
+            name='tsv2img',
+            interface=TSVToImage(t_rep=t_rep))
+        img_to_tsv = pe.Node(name='img2tsv', interface=ImageToTSV())
+        # Copy header information
+        copy_geometry = pe.Node(
+            name='copy_geometry',
+            interface=fsl.utils.CopyGeom(output_type='NIFTI_GZ'))
+
+        workflow.connect([
+            (inputnode, tsv_to_img, [('in_file', 'in_file')]),
+            (tsv_to_img, function_node, [('out_file', input_field)]),
+            (tsv_to_img, copy_geometry, [('out_file', 'in_file')]),
+            (function_node, copy_geometry, [(output_field,'dest_file')]),
+            (copy_geometry, img_to_tsv, [('out_file', 'in_file')]),
+            (tsv_to_img, img_to_tsv, [('header', 'header')]),
+            (img_to_tsv, outputnode, [('out_file', 'out_file')])
+        ])
+    
+    return workflow
 
 
-def tsv_to_1d(tsv, afni1d, transpose=False):
-    """Convert a tsv file into an AFNI 1D file, stripping the header and
-    separately returning it.
-
-    Parameters
-    ----------
-    tsv: str
-        Path to a BIDS-formatted TSV file.
-    afni1d: str
-        Path where the output 1D file should be saved.
-    transpose: bool
-        Indicates whether the observations (e.g., in the time dimension) of
-        the 1D file should run across rows or columns. To process a 1D file
-        with 1D tools, this should be False, but to process a 1D file with 3D
-        tools, this should be True.
-
-    Returns
-    -------
-    str
-        Path to the saved 1D file.
-    list
-        Column names from the TSV header, formatted as a list.
-    """
-    tsv_data = pd.read_csv(tsv, sep='\t', header=None, skiprows=[0])
-    tsv_header = list(pd.read_csv(tsv, sep='\t', nrows=0, header=0).columns)
-    if transpose:
-        tsv_data = tsv_data.T
-    tsv_data.to_csv(afni1d, sep='\t', index=False, na_rep='n/a', header=False)
-    return afni1d, tsv_header
-
-
-def tsv_from_1D(afni1d, tsv, obs='columns', header=None):
-    """Convert an AFNI 1D file into a tsv file. Note that header information
-    will not be included and must be provided separately.
-
-    Parameters
-    ----------
-    afni1d: str
-        Input AFNI 1D file.
-    tsv: str
-        Path where the output TSV should be written.
-    obs: 'rows' or 'columns'
-        Indicates whether the observations (e.g., in the time dimension) of
-        the 1D file run across rows or columns. For a 1D file processed with
-        1D tools, this will be `rows`, but for a 1D file processed with 3D
-        tools, this will be `columns`.
-    header: list
-        List of column names for the output TSV.
-
-    Returns
-    -------
-    str
-        Path to the saved TSV.
-    """
-    # We use a lookbehind to ensure that any leading spaces in the
-    # AFNI 1D file aren't improperly imported into the tsv as NaNs.
-    tsv_data = pd.read_csv(afni1d, sep='(?<!^) ',
-                           header=None, engine='python', comment='#')
-    if obs == 'columns':
-        tsv_data = tsv_data.T
-    if header is not None:
-        tsv_data.columns = header
-    tsv_data.to_tsv(tsv, header=False)
-
-    return tsv
+def _copy_to_1D(src):
+    """A hackish wrapper around shutil functions to trick Nipype."""
+    from shutil import copyfile
+    from nipype.utils.filemanip import split_filename
+    path, name, _ = split_filename(src)
+    dst = '{}/{}.1D'.format(path, name)
+    real_dst = copyfile(src, dst)
+    return real_dst

--- a/niworkflows/func/timeseries1D.py
+++ b/niworkflows/func/timeseries1D.py
@@ -38,7 +38,8 @@ def init_apply_to_2d_wf(function_node,
 
         function_node
             The nipype image processing node that should be applied to the
-            input one- or two-dimensional TSV file.
+            input one- or two-dimensional TSV file. This should be a MapNode
+            with an appropriate ``iterfield`` set.
         t_rep
             Repetition time or sampling interval for the data in the TSV file.
         name
@@ -55,15 +56,15 @@ def init_apply_to_2d_wf(function_node,
 
     **Inputs**
 
-        in_file
-            A one- or two-dimensional TSV file to which the processing step in
-            `function_node` should be applied.
+        in_files
+            A list of one- or two-dimensional TSV files to which the
+            processing step in `function_node` should be applied.
 
 
     **Outputs**
 
-        out_file
-            TSV file with the requested transformation applied.
+        out_files
+            TSV files with the requested transformation applied.
     """
     workflow  = pe.Workflow(name=name)
     
@@ -71,60 +72,63 @@ def init_apply_to_2d_wf(function_node,
     inputnode = pe.Node(
         name='inputnode',
         interface=niu.IdentityInterface(
-            fields=['in_file']
+            fields=['in_files']
     ))
     outputnode = pe.Node(
         name='outputnode',
         interface=niu.IdentityInterface(
-            fields=['out_file']
+            fields=['out_files']
     ))
     
     # Assemble the workflow.
     if mode == 'afni3d':
-        to_1d = pe.Node(name='to_1d', interface=TSVTo1D(transpose=True))
-        from_1d = pe.Node(name='from_1d',
-                          interface=xcp.TSVFrom1D(in_format='columns'))
+        to_1d = pe.MapNode(name='to_1d', iterfield=['in_file'],
+                           interface=TSVTo1D(transpose=True))
+        from_1d = pe.MapNode(name='from_1d', iterfield=['in_file', 'header'],
+                             interface=TSVFrom1D(in_format='columns'))
         # This is extremely hackish, but it seems to be the only way to get
         # AFNI 3D operations to work on 1D files in Nipype as of now
-        suffix_1d_1 = pe.Node(name=('suffix_1D_first'),
+        suffix_1d_1 = pe.MapNode(name=('suffix_1D_first'), iterfield=['src'],
             interface=niu.Function(
                 input_names=['src'],
                 output_names=['real_dst'],
-                function=_move_ifc))
-        suffix_1d_2 = pe.Node(name=('suffix_1D_second'),
+                function=_copy_to_1D))
+        suffix_1d_2 = pe.MapNode(name=('suffix_1D_second'), iterfield=['src'],
             interface=niu.Function(
                 input_names=['src'],
                 output_names=['real_dst'],
-                function=_move_ifc))
+                function=_copy_to_1D))
 
         workflow.connect([
-            (inputnode, to_1d, [('in_file', 'in_file')]),
+            (inputnode, to_1d, [('in_files', 'in_file')]),
             (to_1d, suffix_1d_1, [('out_file', 'src')]),
             (suffix_1d_1, function_node, [('real_dst', input_field)]),
             (function_node, suffix_1d_2, [(output_field, 'src')]),
             (suffix_1d_2, from_1d, [('real_dst', 'in_file')]),
             (to_1d, from_1d, [('header', 'header')]),
-            (from_1d, outputnode, [('out_file', 'out_file')])
+            (from_1d, outputnode, [('out_file', 'out_files')])
         ])
     else:
         # Map tsv to image and image to tsv
-        tsv_to_img = pe.Node(
-            name='tsv2img',
+        tsv_to_img = pe.MapNode(
+            name='tsv2img', iterfield=['in_file'],
             interface=TSVToImage(t_rep=t_rep))
-        img_to_tsv = pe.Node(name='img2tsv', interface=ImageToTSV())
+        img_to_tsv = pe.MapNode(
+            interface=ImageToTSV(),
+            name='img2tsv', iterfield=['in_file', 'header'])
         # Copy header information
-        copy_geometry = pe.Node(
-            name='copy_geometry',
+        copy_geometry = pe.MapNode(
+            name='copy_geometry', iterfield=['in_file', 'dest_file'],
             interface=fsl.utils.CopyGeom(output_type='NIFTI_GZ'))
 
         workflow.connect([
-            (inputnode, tsv_to_img, [('in_file', 'in_file')]),
+            (inputnode, tsv_to_img, [('in_files', 'in_file')]),
             (tsv_to_img, function_node, [('out_file', input_field)]),
             (tsv_to_img, copy_geometry, [('out_file', 'in_file')]),
             (function_node, copy_geometry, [(output_field,'dest_file')]),
             (copy_geometry, img_to_tsv, [('out_file', 'in_file')]),
             (tsv_to_img, img_to_tsv, [('header', 'header')]),
-            (img_to_tsv, outputnode, [('out_file', 'out_file')])
+            (img_to_tsv, outputnode, [('out_file', 'out_files')])
         ])
     
     return workflow

--- a/niworkflows/func/timeseries1D.py
+++ b/niworkflows/func/timeseries1D.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+"""
+Operations to apply analytic tools designed for 4D NIfTI time series to
+2D TSV files.
+"""
+from nipype.utils.filemanip import fname_presuffix
+from nipype.interfaces.base import (
+    traits, TraitedSpec, BaseInterfaceInputSpec, SimpleInterface, File)
+from .filter import _unfold_image
+
+
+class TSVToImageInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc='TSV file')
+    t_rep = traits.Float(mandatory=True, desc='Repetition time')
+
+
+class TSVToImageOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc='Image derived from input TSV')
+    header = traits.CList(traits.Str, desc='Header stripped from TSV')
+
+
+class TSVToImage(SimpleInterface):
+    """Convert a TSV into an image"""
+    input_spec = TSVToImageInputSpec
+    output_spec = TSVToImageOutputSpec
+
+    def _run_interface(self, runtime):
+        out_file = fname_presuffix(self.inputs.in_file,
+                                   suffix='_TSVToImage.nii.gz',
+                                   newpath=runtime.cwd,
+                                   use_ext=False)
+        (self._results['out_file'],
+         self._results['header']) = tsv2img(tsv=self.inputs.in_file,
+                                            img=out_file,
+                                            t_rep=self.inputs.t_rep)
+        return runtime
+
+
+class ImageToTSVInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc='NIfTI file')
+    mask = traits.Either(
+        None, File(exists=True), default=None, usedefault=True,
+        desc='NIfTI mask for TSV extraction')
+    header = traits.CList(traits.Str, desc='Header for TSV columns')
+
+
+class ImageToTSVOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc='TSV derived from input image')
+
+
+class ImageToTSV(SimpleInterface):
+    """Convert an image into a TSV."""
+    input_spec = ImageToTSVInputSpec
+    output_spec = ImageToTSVOutputSpec
+
+    def _run_interface(self, runtime):
+        out_file = fname_presuffix(self.inputs.in_file,
+                                   suffix='_imageToTSV.tsv',
+                                   newpath=runtime.cwd,
+                                   use_ext=False)
+        self._results['out_file'] = img2tsv(img=self.inputs.in_file,
+                                            tsv=out_file,
+                                            mask=self.inputs.mask,
+                                            header=self.inputs.header)
+        return runtime
+
+
+class TSVTo1DInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc='TSV to transpose')
+    transpose = traits.Bool(usedefault=True, desc='Indicates whether the '
+                            'data should be transposed before saving as 1D')
+
+
+class TSVTo1DOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc='transposed TSV')
+    header = traits.CList(traits.Str, desc='header stripped from TSV')
+
+
+class TSVTo1D(SimpleInterface):
+    """Convert a TSV file to a 1D file that can be used with AFNI."""
+    input_spec = TSVTransposeInputSpec
+    output_spec = TSVTransposeOutputSpec
+
+    def _run_interface(self, runtime):
+        out_file = fname_presuffix(self.inputs.in_file,
+                                   suffix='_TSVto1D',
+                                   newpath=runtime.cwd)
+        (self._results['out_file'],
+         self._results['header']) = tsv_to_1d(tsv=self.inputs.in_file,
+                                              afni1d=out_file,
+                                              transpose=self.inputs.transpose)
+        return runtime
+
+
+class TSVFrom1DInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc='AFNI 1D file')
+    in_format = traits.Enum(
+        'columns', 'rows', usedefault=True,
+        desc='format of the 1D file (observations in `rows` or `columns`)')
+    header = traits.Either(None, traits.List, default=None, usedefault=True,
+                           desc='header to prepend to the output TSV')
+
+
+class TSVFrom1DOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc='TSV derived from input 1D file')
+
+
+class TSVFrom1D(SimpleInterface):
+    """Convert an AFNI 1D file to (potentially) BIDS-compatible TSV format."""
+    input_spec = TSVFrom1DInputSpec
+    output_spec = TSVFrom1DOutputSpec
+
+    def _run_interface(self, runtime):
+        out_file = fname_presuffix(self.inputs.in_file,
+                                   suffix='_TSVfrom1D',
+                                   newpath=runtime.cwd)
+
+        self._results['out_file'] = tsv_from_1D(afni1d=self.inputs.in_file,
+                                                tsv=out_file,
+                                                format=self.inputs.in_format,
+                                                header=self.inputs.header)
+
+        return runtime
+
+
+def tsv2img(tsv, img, t_rep):
+    """Create a dummy NIfTI image out of a tsv file, thus enabling it to be
+    processed through nodes that ordinarily only operate on valid image files.
+
+    Note that dummy NIfTIs must explicitly have repetition time set via input
+    to this function, and the affine of a dummy NIfTI is identity.
+    
+    Parameters
+    ----------
+    tsv: str
+        Path to the TSV file to be converted into an image.
+    img: str
+        Path where the converted file should be saved.
+    t_rep: float
+        Repetition time or sampling interval of the dataset.
+
+    Returns
+    -------
+    str
+        Path to the image generated from the TSV file.
+    list
+        Column names from the TSV header, formatted as a list, so that they
+        can potentially be added later if the image is converted back.
+    """
+    tsv_data = pd.read_csv(tsv, header=None, skiprows=[0], sep='\t').values.T
+    tsv_data.shape = [tsv_data.shape[0],1,1,tsv_data.shape[1]]
+    header = list(pd.read_csv(tsv, sep='\t', nrows=0, header=0).columns)
+    img = nib.Nifti1Image(dataobj=tsv_data, affine=np.eye(4))
+    tsv_img.header['pixdim'][4] = t_rep
+    nib.save(tsv_img, img)
+    return img, header
+
+
+def img2tsv(img, tsv, mask=None, header=None):
+    """Dump data from an image file into tabular form.
+
+    Parameters
+    ----------
+    img
+        The time series image to be dumped into TSV form.
+    tsv
+        The path where the TSV should be saved.
+    mask
+        Spatial mask indicating voxels of the image to include in the TSV.
+    header
+        Header to be added to the output TSV file.
+
+    Returns
+    -------
+    str
+        Path to the TSV generated from image data.
+    """
+    img = nib.load(img)
+    img_data = _unfold_image(img, mask=mask)
+
+    if header is not None:
+        tsv_data = DataFrame(data=img_data.T, columns=header)
+        tsv_data.to_csv(tsv, sep='\t', index=False,
+                        na_rep='n/a', header=True)
+    else:
+        tsv_data = DataFrame(data=img_data.T)
+        tsv_data.to_csv(tsv, sep='\t', index=False,
+                        na_rep='n/a', header=False)
+    return tsv
+
+
+def tsv_to_1d(tsv, afni1d, transpose=False):
+    """Convert a tsv file into an AFNI 1D file, stripping the header and
+    separately returning it.
+
+    Parameters
+    ----------
+    tsv: str
+        Path to a BIDS-formatted TSV file.
+    afni1d: str
+        Path where the output 1D file should be saved.
+    transpose: bool
+        Indicates whether the observations (e.g., in the time dimension) of
+        the 1D file should run across rows or columns. To process a 1D file
+        with 1D tools, this should be False, but to process a 1D file with 3D
+        tools, this should be True.
+
+    Returns
+    -------
+    str
+        Path to the saved 1D file.
+    list
+        Column names from the TSV header, formatted as a list.
+    """
+    tsv_data = pd.read_csv(tsv, sep='\t', header=None, skiprows=[0])
+    tsv_header = list(pd.read_csv(tsv, sep='\t', nrows=0, header=0).columns)
+    if transpose:
+        tsv_data = tsv_data.T
+    tsv_data.to_csv(afni1d, sep='\t', index=False, na_rep='n/a', header=False)
+    return afni1d, tsv_header
+
+
+def tsv_from_1D(afni1d, tsv, obs='columns', header=None):
+    """Convert an AFNI 1D file into a tsv file. Note that header information
+    will not be included and must be provided separately.
+
+    Parameters
+    ----------
+    afni1d: str
+        Input AFNI 1D file.
+    tsv: str
+        Path where the output TSV should be written.
+    obs: 'rows' or 'columns'
+        Indicates whether the observations (e.g., in the time dimension) of
+        the 1D file run across rows or columns. For a 1D file processed with
+        1D tools, this will be `rows`, but for a 1D file processed with 3D
+        tools, this will be `columns`.
+    header: list
+        List of column names for the output TSV.
+
+    Returns
+    -------
+    str
+        Path to the saved TSV.
+    """
+    # We use a lookbehind to ensure that any leading spaces in the
+    # AFNI 1D file aren't improperly imported into the tsv as NaNs.
+    tsv_data = pd.read_csv(afni1d, sep='(?<!^) ',
+                           header=None, engine='python', comment='#')
+    if obs == 'columns':
+        tsv_data = tsv_data.T
+    if header is not None:
+        tsv_data.columns = header
+    tsv_data.to_tsv(tsv, header=False)
+
+    return tsv

--- a/niworkflows/interfaces/__init__.py
+++ b/niworkflows/interfaces/__init__.py
@@ -4,6 +4,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from .confounds import ExpandModel, SpikeRegressors
+from .filter import (
+	TemporalFilter4D, TemporalFilter2D,
+	Interpolate4D, Interpolate2D,
+	DemeanDetrend4D, DemeanDetrend2D
+)
 from .masks import BETRPT as BET
 from .segmentation import (FASTRPT as FAST)
 from .registration import (FLIRTRPT as FLIRT,

--- a/niworkflows/interfaces/__init__.py
+++ b/niworkflows/interfaces/__init__.py
@@ -5,9 +5,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from .confounds import ExpandModel, SpikeRegressors
 from .filter import (
-	TemporalFilter4D, TemporalFilter2D,
-	Interpolate4D, Interpolate2D,
-	DemeanDetrend4D, DemeanDetrend2D
+    TemporalFilter4D, TemporalFilter2D,
+    Interpolate4D, Interpolate2D,
+    DemeanDetrend4D, DemeanDetrend2D
 )
 from .masks import BETRPT as BET
 from .segmentation import (FASTRPT as FAST)

--- a/niworkflows/interfaces/filter.py
+++ b/niworkflows/interfaces/filter.py
@@ -141,9 +141,9 @@ class Interpolate4DInputSpec(BaseInterfaceInputSpec):
                          desc='Repetition time (T_R)')
     os_freq = traits.Int(8, usedefault=True,
                          desc='Oversampling frequency')
-    maxfreq = traits.Float(
+    max_freq = traits.Float(
         1, usedefault=True, desc='Max frequency, as a fraction of Nyquist')
-    voxbin = traits.Int(
+    vox_bin = traits.Int(
         5000, usedefault=True, desc='Number of voxels to transform at a time')
     output_file = File(desc='Output path')
 
@@ -172,9 +172,51 @@ class Interpolate4D(SimpleInterface):
             brain_mask=self.inputs.mask,
             temporal_mask=self.inputs.tmask,
             t_rep=self.inputs.t_rep,
-            oversampling_frequency=self.inputs.ofreq,
-            maximum_frequency=self.inputs.maxfreq,
-            voxel_bin_size=self.inputs.voxbin
+            oversampling_frequency=self.inputs.os_freq,
+            maximum_frequency=self.inputs.max_freq,
+            voxel_bin_size=self.inputs.vox_bin
+        )
+        return runtime
+
+
+class Interpolate2DInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True,
+                   desc='1D or 2D TSV time series to be transformed')
+    tmask = File(exists=True, mandatory=True,
+                 desc='Temporal mask')
+    t_rep = traits.Float(usedefault=False, mandatory=True,
+                         desc='Repetition time (T_R)')
+    os_freq = traits.Int(8, usedefault=True,
+                         desc='Oversampling frequency')
+    max_freq = traits.Float(
+        1, usedefault=True, desc='Max frequency, as a fraction of Nyquist')
+    output_file = File(desc='Output path')
+
+
+class Interpolate2DOutputSpec(TraitedSpec):
+    output_file = File(exists=True, desc='Interpolated TSV file')
+
+
+class Interpolate2D(SimpleInterface):
+
+    input_spec = Interpolate2DInputSpec
+    output_spec = Interpolate2DOutputSpec
+
+    def _run_interface(self, runtime):
+        if isdefined(self.inputs.output_file):
+            out_file = self.inputs.output_file
+        else:
+            out_file = fname_presuffix(self.inputs.in_file,
+                                       suffix='_interpolate2D',
+                                       newpath=runtime.cwd)
+
+        self._results['output_file'] = interpolate_lombscargle_2d(
+            timeseries_2d=self.inputs.in_file,
+            timeseries_2d_out=out_file,
+            temporal_mask=self.inputs.tmask,
+            t_rep=self.inputs.t_rep,
+            oversampling_frequency=self.inputs.os_freq,
+            maximum_frequency=self.inputs.max_freq
         )
         return runtime
 

--- a/niworkflows/interfaces/filter.py
+++ b/niworkflows/interfaces/filter.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+
+"""
+Temporal filtering operations for the image processing system
+"""
+
+import numpy as np
+
+
+def _validate_passband(filter_type, passband):
+    """Verify that the filter passband is reasonably formulated.
+
+    Parameters
+    ----------
+    filter_type: str
+        String indicating the type of filter.
+    passband: tuple
+        2-tuple indicating high-pass and low-pass cutoffs for the filter.
+    """
+    if passband[0] > passband[1]:
+        raise ValueError(
+            '\n'
+            'High-pass cutoff must be less than low-pass cutoff\n'
+            'for the selected filter type.\n'
+            '==================================================\n'
+            'Filter class:     {0}\n'
+            'High-pass cutoff: {1[0]}\n'
+            'Low-pass cutoff:  {1[1]}\n'.format(filter_type, passband))
+
+
+def _get_fsl_passband(passband, sampling_rate):
+    """
+    Convert the passband to a form that FSL can understand.
+    For use when filtering with a Gaussian kernel.
+    1) Convert the cutoff frequencies from Hz (cycles per second) to cycles
+       per repetition.
+    2) Convert from frequency cutoff (in Hz) to cycle cutoff (in s). 
+    3) Then, determine how many cycles of the cutoff per repetition.
+
+    Parameters
+    ----------
+    passband: tuple
+        2-tuple indicating high-pass and low-pass cutoffs for the filter.
+    sampling_rate: float
+        Repetition time.
+
+    Returns
+    -------
+    tuple
+        FSL-compatible passband.
+    """
+    passband_frequency = (0, -1)
+    passband_frequency[0] = (1/passband[0])/(2 * sampling_rate)
+    if passband[1] == 'nyquist':
+        passband_frequency[1] = -1
+    else:
+        passband_frequency[1] = 1/passband[1]/(2 * sampling_rate)
+    return passband_frequency
+
+
+def _normalise_passband(passband, nyquist):
+    """Normalise the passband according to the Nyquist frequency."""
+    passband_norm = (0, 1)
+
+    passband_norm[0] = float(passband[0])/nyquist
+    if passband[1] == 'nyquist':
+        passband_norm[1] = 1
+    else:
+        passband_norm[1] = float(passband[1])/nyquist
+    return passband_norm
+
+
+def _get_norm_passband(passband, sampling_rate):
+    """Convert the passband to normalised form.
+
+    Parameters
+    ----------
+    passband: tuple
+        2-tuple indicating high-pass and low-pass cutoffs for the filter.
+    sampling_rate: float
+        Repetition time.
+
+    Returns
+    -------
+    tuple
+        Cutoff frequencies normalised between 0 and Nyquist.
+    None or str
+        Indicator of whether the filter is permissive at high or low
+        frequencies. If None, this determination is 
+    """
+    nyquist = 0.5 * sampling_rate
+    passband_norm = _normalise_passband(passband, nyquist)
+
+    if passband_norm[1] >= 1:
+        filter_pass = 'highpass'
+    if passband_norm[0] <= 0:
+        if filter_pass == 'highpass':
+            raise ValueError(
+                '\n'
+                'Permissive filter for the specified sampling rate.\n'
+                '==================================================\n'
+                'Sampling rate:     {0}\n'
+                'Nyquist frequency: {1}\n'
+                'High-pass cutoff:  {2[0]}\n'
+                'Low-pass cutoff:   {2[1]}\n'.format(
+                    sampling_rate, nyquist, passband))
+        passband_norm[0] = 0
+        filter_pass = 'lowpass'
+
+    if filter_pass == 'highpass':
+        passband_norm = passband_norm[0]
+    elif filter_pass == 'lowpass':
+        passband_norm = passband_norm[1]
+    elif passband_norm[0] > passband_norm[1]:
+        filter_pass = 'bandstop'
+    else:
+        filter_pass = 'bandpass'
+    return passband_norm, filter_pass

--- a/niworkflows/interfaces/filter.py
+++ b/niworkflows/interfaces/filter.py
@@ -98,7 +98,8 @@ class TemporalFilter2DInputSpec(BaseInterfaceInputSpec):
 
 
 class TemporalFilter2DOutputSpec(TraitedSpec):
-    out_file = File(exists=True, desc='Temporally filtered TSV time series')
+    output_file = File(
+        exists=True, desc='Temporally filtered TSV time series')
 
 
 class TemporalFilter2D(SimpleInterface):
@@ -115,7 +116,7 @@ class TemporalFilter2D(SimpleInterface):
                                        suffix='_filter2D',
                                        newpath=runtime.cwd)
 
-        self._results['out_file'] = general_filter_2d(
+        self._results['output_file'] = general_filter_2d(
             timeseries_2d=self.inputs.in_file,
             t_rep=self.inputs.t_rep,
             timeseries_2d_out=out_file,
@@ -124,6 +125,56 @@ class TemporalFilter2D(SimpleInterface):
             passband=self.inputs.passband,
             ripple_pass=self.inputs.ripple_pass,
             ripple_stop=self.inputs.ripple_stop
+        )
+        return runtime
+
+
+
+class Interpolate4DInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True,
+                   desc='4D NIfTI time series to be transformed')
+    tmask = File(exists=True, mandatory=True,
+                 desc='Temporal mask')
+    mask = File(exists=True,
+                desc='Spatial mask')
+    t_rep = traits.Float(usedefault=False,
+                         desc='Repetition time (T_R)')
+    os_freq = traits.Int(8, usedefault=True,
+                         desc='Oversampling frequency')
+    maxfreq = traits.Float(
+        1, usedefault=True, desc='Max frequency, as a fraction of Nyquist')
+    voxbin = traits.Int(
+        5000, usedefault=True, desc='Number of voxels to transform at a time')
+    output_file = File(desc='Output path')
+
+
+class Interpolate4DOutputSpec(TraitedSpec):
+    output_file = File(exists=True, desc='Interpolated 4D NIfTI file')
+
+
+class Interpolate4D(SimpleInterface):
+    """Interpolate a 4D NIfTI time series.
+    """
+    input_spec = Interpolate4DInputSpec
+    output_spec = Interpolate4DOutputSpec
+
+    def _run_interface(self, runtime):
+        if isdefined(self.inputs.output_file):
+            out_file = self.inputs.output_file
+        else:
+            out_file = fname_presuffix(self.inputs.in_file,
+                                       suffix='_interpolate4D',
+                                       newpath=runtime.cwd)
+
+        self._results['output_file'] = interpolate_lombscargle_4d(
+            timeseries_4d=self.inputs.in_file,
+            timeseries_4d_out=out_file,
+            brain_mask=self.inputs.mask,
+            temporal_mask=self.inputs.tmask,
+            t_rep=self.inputs.t_rep,
+            oversampling_frequency=self.inputs.ofreq,
+            maximum_frequency=self.inputs.maxfreq,
+            voxel_bin_size=self.inputs.voxbin
         )
         return runtime
 

--- a/niworkflows/interfaces/filter.py
+++ b/niworkflows/interfaces/filter.py
@@ -869,8 +869,8 @@ def interpolate_lombscargle_4d(timeseries_4d,
 
     tmask = pd.read_csv(
         temporal_mask, sep='\t').values.astype('bool').squeeze()
-    (sine_term, cosine_term, angular_frequencies, all_samples, nvol
-    ) = periodogram_cfg(
+    (sine_term, cosine_term, angular_frequencies, all_samples,
+     nvol) = periodogram_cfg(
         tmask=tmask,
         sampling_period=t_rep,
         oversampling_frequency=oversampling_frequency,
@@ -962,8 +962,8 @@ def interpolate_lombscargle_2d(timeseries_2d,
                 in tsv_data.columns[tsv_data.isnull().any()]])
     for data in datasets:
         tmask_cur = np.logical_and(data.notnull().any(axis=1), tmask)
-        (sine_term, cosine_term, angular_frequencies, all_samples, nobs
-        ) = periodogram_cfg(
+        (sine_term, cosine_term, angular_frequencies, all_samples,
+         nobs) = periodogram_cfg(
             tmask=tmask_cur,
             sampling_period=t_rep,
             oversampling_frequency=oversampling_frequency,

--- a/niworkflows/interfaces/filter.py
+++ b/niworkflows/interfaces/filter.py
@@ -1044,3 +1044,45 @@ def demean_detrend_4d(timeseries_4d,
         nib.save(img_mean, mean_out)
 
     return timeseries_4d_out, mean_out
+
+
+def demean_detrend_2d(timeseries_2d,
+                      timeseries_2d_out,
+                      detrend_order,
+                      detrend_type='polynomial',
+                      temporal_mask=None):
+
+    """Demean and detrend a 2D TSV dataset.
+
+    Parameters
+    ----------
+    timeseries_2d: str
+        Path to the 2-dimensional TSV time series dataset that is to be
+        demeaned and detrended via polynomial fit. The fit is applied over
+        the fourth (temporal) axis.
+    timeseries_2d_out: str
+        Path where the detrended time series dataset will be saved.
+    detrend_order: int
+        The degree of polynomial to be fit as part of the detrend protocol.
+        (order 0: demean; order 1: linear; order 2: quadratic; . . .)
+    detrend_type: str
+        Type of polynomial fit. Either `legendre` or `polynomial`. Both yield
+        identical results, so there isn't really much reason to use this
+        option.
+    temporal_mask: str
+        Temporal mask file indicating whether the value in each frame should
+        be considered in the polynomial fit.
+
+    Returns
+    -------
+    str
+        Saved and detrended TSV time series.
+    """
+    tsv_data = read_csv(timeseries_2d, sep='\t')
+    tsv_data[:] = demean_detrend(data=tsv_data.values.T,
+                                 detrend_order=detrend_order,
+                                 detrend_type=detrend_type,
+                                 temporal_mask=temporal_mask,
+                                 save_mean=False)
+    tsv_data.to_csv(timeseries_2d_out, sep='\t', index=False, na_rep='n/a')
+    return timeseries_2d_out

--- a/niworkflows/interfaces/timeseries1D.py
+++ b/niworkflows/interfaces/timeseries1D.py
@@ -135,7 +135,7 @@ def tsv2img(tsv, img, t_rep):
 
     Note that dummy NIfTIs must explicitly have repetition time set via input
     to this function, and the affine of a dummy NIfTI is identity.
-    
+
     Parameters
     ----------
     tsv: str
@@ -154,7 +154,7 @@ def tsv2img(tsv, img, t_rep):
         can potentially be added later if the image is converted back.
     """
     tsv_data = pd.read_csv(tsv, header=None, skiprows=[0], sep='\t').values.T
-    tsv_data.shape = [tsv_data.shape[0],1,1,tsv_data.shape[1]]
+    tsv_data.shape = [tsv_data.shape[0], 1, 1, tsv_data.shape[1]]
     header = list(pd.read_csv(tsv, sep='\t', nrows=0, header=0).columns)
     img_data = nb.Nifti1Image(dataobj=tsv_data, affine=np.eye(4))
     img_data.header['pixdim'][4] = t_rep

--- a/niworkflows/interfaces/timeseries1D.py
+++ b/niworkflows/interfaces/timeseries1D.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+"""
+Operations to apply analytic tools designed for 4D NIfTI time series to
+2D TSV files.
+"""
+from nipype.utils.filemanip import fname_presuffix
+from nipype.interfaces.base import (
+    traits, TraitedSpec, BaseInterfaceInputSpec, SimpleInterface, File)
+from .filter import _unfold_image
+
+
+class TSVToImageInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc='TSV file')
+    t_rep = traits.Float(mandatory=True, desc='Repetition time')
+
+
+class TSVToImageOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc='Image derived from input TSV')
+    header = traits.CList(traits.Str, desc='Header stripped from TSV')
+
+
+class TSVToImage(SimpleInterface):
+    """Convert a TSV into an image"""
+    input_spec = TSVToImageInputSpec
+    output_spec = TSVToImageOutputSpec
+
+    def _run_interface(self, runtime):
+        out_file = fname_presuffix(self.inputs.in_file,
+                                   suffix='_TSVToImage.nii.gz',
+                                   newpath=runtime.cwd,
+                                   use_ext=False)
+        (self._results['out_file'],
+         self._results['header']) = tsv2img(tsv=self.inputs.in_file,
+                                            img=out_file,
+                                            t_rep=self.inputs.t_rep)
+        return runtime
+
+
+class ImageToTSVInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc='NIfTI file')
+    mask = traits.Either(
+        None, File(exists=True), default=None, usedefault=True,
+        desc='NIfTI mask for TSV extraction')
+    header = traits.CList(traits.Str, desc='Header for TSV columns')
+
+
+class ImageToTSVOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc='TSV derived from input image')
+
+
+class ImageToTSV(SimpleInterface):
+    """Convert an image into a TSV."""
+    input_spec = ImageToTSVInputSpec
+    output_spec = ImageToTSVOutputSpec
+
+    def _run_interface(self, runtime):
+        out_file = fname_presuffix(self.inputs.in_file,
+                                   suffix='_imageToTSV.tsv',
+                                   newpath=runtime.cwd,
+                                   use_ext=False)
+        self._results['out_file'] = img2tsv(img=self.inputs.in_file,
+                                            tsv=out_file,
+                                            mask=self.inputs.mask,
+                                            header=self.inputs.header)
+        return runtime
+
+
+class TSVTo1DInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc='TSV to transpose')
+    transpose = traits.Bool(usedefault=True, desc='Indicates whether the '
+                            'data should be transposed before saving as 1D')
+
+
+class TSVTo1DOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc='transposed TSV')
+    header = traits.CList(traits.Str, desc='header stripped from TSV')
+
+
+class TSVTo1D(SimpleInterface):
+    """Convert a TSV file to a 1D file that can be used with AFNI."""
+    input_spec = TSVTo1DInputSpec
+    output_spec = TSVTo1DOutputSpec
+
+    def _run_interface(self, runtime):
+        out_file = fname_presuffix(self.inputs.in_file,
+                                   suffix='_TSVto1D',
+                                   newpath=runtime.cwd)
+        (self._results['out_file'],
+         self._results['header']) = tsv_to_1d(tsv=self.inputs.in_file,
+                                              afni1d=out_file,
+                                              transpose=self.inputs.transpose)
+        return runtime
+
+
+class TSVFrom1DInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc='AFNI 1D file')
+    in_format = traits.Enum(
+        'columns', 'rows', usedefault=True,
+        desc='format of the 1D file (observations in `rows` or `columns`)')
+    header = traits.Either(None, traits.List, default=None, usedefault=True,
+                           desc='header to prepend to the output TSV')
+
+
+class TSVFrom1DOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc='TSV derived from input 1D file')
+
+
+class TSVFrom1D(SimpleInterface):
+    """Convert an AFNI 1D file to (potentially) BIDS-compatible TSV format."""
+    input_spec = TSVFrom1DInputSpec
+    output_spec = TSVFrom1DOutputSpec
+
+    def _run_interface(self, runtime):
+        out_file = fname_presuffix(self.inputs.in_file,
+                                   suffix='_TSVfrom1D',
+                                   newpath=runtime.cwd)
+
+        self._results['out_file'] = tsv_from_1D(afni1d=self.inputs.in_file,
+                                                tsv=out_file,
+                                                format=self.inputs.in_format,
+                                                header=self.inputs.header)
+
+        return runtime
+
+
+def tsv2img(tsv, img, t_rep):
+    """Create a dummy NIfTI image out of a tsv file, thus enabling it to be
+    processed through nodes that ordinarily only operate on valid image files.
+
+    Note that dummy NIfTIs must explicitly have repetition time set via input
+    to this function, and the affine of a dummy NIfTI is identity.
+    
+    Parameters
+    ----------
+    tsv: str
+        Path to the TSV file to be converted into an image.
+    img: str
+        Path where the converted file should be saved.
+    t_rep: float
+        Repetition time or sampling interval of the dataset.
+
+    Returns
+    -------
+    str
+        Path to the image generated from the TSV file.
+    list
+        Column names from the TSV header, formatted as a list, so that they
+        can potentially be added later if the image is converted back.
+    """
+    tsv_data = pd.read_csv(tsv, header=None, skiprows=[0], sep='\t').values.T
+    tsv_data.shape = [tsv_data.shape[0],1,1,tsv_data.shape[1]]
+    header = list(pd.read_csv(tsv, sep='\t', nrows=0, header=0).columns)
+    img = nib.Nifti1Image(dataobj=tsv_data, affine=np.eye(4))
+    tsv_img.header['pixdim'][4] = t_rep
+    nib.save(tsv_img, img)
+    return img, header
+
+
+def img2tsv(img, tsv, mask=None, header=None):
+    """Dump data from an image file into tabular form.
+
+    Parameters
+    ----------
+    img
+        The time series image to be dumped into TSV form.
+    tsv
+        The path where the TSV should be saved.
+    mask
+        Spatial mask indicating voxels of the image to include in the TSV.
+    header
+        Header to be added to the output TSV file.
+
+    Returns
+    -------
+    str
+        Path to the TSV generated from image data.
+    """
+    img = nib.load(img)
+    img_data = _unfold_image(img, mask=mask)
+
+    if header is not None:
+        tsv_data = DataFrame(data=img_data.T, columns=header)
+        tsv_data.to_csv(tsv, sep='\t', index=False,
+                        na_rep='n/a', header=True)
+    else:
+        tsv_data = DataFrame(data=img_data.T)
+        tsv_data.to_csv(tsv, sep='\t', index=False,
+                        na_rep='n/a', header=False)
+    return tsv
+
+
+def tsv_to_1d(tsv, afni1d, transpose=False):
+    """Convert a tsv file into an AFNI 1D file, stripping the header and
+    separately returning it.
+
+    Parameters
+    ----------
+    tsv: str
+        Path to a BIDS-formatted TSV file.
+    afni1d: str
+        Path where the output 1D file should be saved.
+    transpose: bool
+        Indicates whether the observations (e.g., in the time dimension) of
+        the 1D file should run across rows or columns. To process a 1D file
+        with 1D tools, this should be False, but to process a 1D file with 3D
+        tools, this should be True.
+
+    Returns
+    -------
+    str
+        Path to the saved 1D file.
+    list
+        Column names from the TSV header, formatted as a list.
+    """
+    tsv_data = pd.read_csv(tsv, sep='\t', header=None, skiprows=[0])
+    tsv_header = list(pd.read_csv(tsv, sep='\t', nrows=0, header=0).columns)
+    if transpose:
+        tsv_data = tsv_data.T
+    tsv_data.to_csv(afni1d, sep='\t', index=False, na_rep='n/a', header=False)
+    return afni1d, tsv_header
+
+
+def tsv_from_1D(afni1d, tsv, obs='columns', header=None):
+    """Convert an AFNI 1D file into a tsv file. Note that header information
+    will not be included and must be provided separately.
+
+    Parameters
+    ----------
+    afni1d: str
+        Input AFNI 1D file.
+    tsv: str
+        Path where the output TSV should be written.
+    obs: 'rows' or 'columns'
+        Indicates whether the observations (e.g., in the time dimension) of
+        the 1D file run across rows or columns. For a 1D file processed with
+        1D tools, this will be `rows`, but for a 1D file processed with 3D
+        tools, this will be `columns`.
+    header: list
+        List of column names for the output TSV.
+
+    Returns
+    -------
+    str
+        Path to the saved TSV.
+    """
+    # We use a lookbehind to ensure that any leading spaces in the
+    # AFNI 1D file aren't improperly imported into the tsv as NaNs.
+    tsv_data = pd.read_csv(afni1d, sep='(?<!^) ',
+                           header=None, engine='python', comment='#')
+    if obs == 'columns':
+        tsv_data = tsv_data.T
+    if header is not None:
+        tsv_data.columns = header
+    tsv_data.to_tsv(tsv, header=False)
+
+    return tsv


### PR DESCRIPTION
This PR addresses issue #311.

* A generalised temporal filtering workflow applies identical operations to any number of 4D (NIfTI) and 2D (TSV) timeseries provided as input, enabling [synchronous filtering of confounds and data](https://www.ncbi.nlm.nih.gov/pubmed/23747457).
* Available filters are derived from scipy (Butterworth, Chebyshev, and elliptic filters), AFNI (FFT-based filter), and FSL (Gaussian kernel convolutional filter).
* To fully enable the latter filters, an additional workflow is included for applying any 4D image processing function to 2D data. The AFNI arm of that workflow leverages existing functionality within AFNI (see [1D files as AFNI datasets here](https://afni.nimh.nih.gov/pub/dist/doc/program_help/common_options.html)); however, its implementation is rather hackish (as Nipype doesn't allow 1d as a valid AFNI `outputtype`) and should potentially be brought up as a Nipype issue.
* (Note: if you're using a fit-based filter -- for instance with the cosine basis functions provided with fmriprep -- you probably should be doing single-pass filtering and regression rather than using a workflow like this.)
* The filtering workflow optionally incorporates a demean/detrend step and an interpolation step to reduce the impact of high-motion frames. Despiking might also be worth considering.

Marking as WIP, as more robust testing still needs to be performed and appropriate unit tests probably added.