### PR TITLE
ENH: Allow bold_reference_wf to accept multiple EPIs/SBRefs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,8 +151,8 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - regression-v4-{{ .Revision }}
-            - regression-v4-
+            - regression-v5-{{ .Revision }}
+            - regression-v5-
       - run:
           name: Get truncated BOLD series
           command: |
@@ -175,7 +175,7 @@ jobs:
               echo "Pre-computed masks were cached"
             fi
       - save_cache:
-         key: regression-v4-{{ .Revision }}-{{ epoch }}
+         key: regression-v5-{{ .Revision }}-{{ epoch }}
          paths:
             - /tmp/data
 
@@ -284,7 +284,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - regression-v4-{{ .Revision }}
+            - regression-v5-{{ .Revision }}
       - restore_cache:
           keys:
             - masks-workdir-v2-{{ .Branch }}-{{epoch}}

--- a/niworkflows/anat/ants.py
+++ b/niworkflows/anat/ants.py
@@ -15,7 +15,7 @@ from nipype.interfaces import utility as niu
 from nipype.interfaces.fsl.maths import ApplyMask
 from nipype.interfaces.ants import N4BiasFieldCorrection, Atropos, MultiplyImages
 
-from ..utils.misc import get_template_specs
+from ..utils.misc import get_template_specs, select_first as _pop
 
 # niworkflows
 from ..interfaces.ants import (
@@ -895,12 +895,6 @@ def init_n4_only_wf(
         # fmt: on
 
     return wf
-
-
-def _pop(in_files):
-    if isinstance(in_files, (list, tuple)):
-        return in_files[0]
-    return in_files
 
 
 def _select_labels(in_segm, labels):

--- a/niworkflows/anat/ants.py
+++ b/niworkflows/anat/ants.py
@@ -15,7 +15,8 @@ from nipype.interfaces import utility as niu
 from nipype.interfaces.fsl.maths import ApplyMask
 from nipype.interfaces.ants import N4BiasFieldCorrection, Atropos, MultiplyImages
 
-from ..utils.misc import get_template_specs, select_first as _pop
+from ..utils.misc import get_template_specs
+from ..utils.connections import pop_file as _pop
 
 # niworkflows
 from ..interfaces.ants import (

--- a/niworkflows/func/tests/test_util.py
+++ b/niworkflows/func/tests/test_util.py
@@ -1,16 +1,46 @@
-""" Testing module for fmriprep.workflows.bold.util """
+"""Testing module for fmriprep.workflows.bold.util."""
 import pytest
 import os
 from pathlib import Path
 
 import numpy as np
 from nipype.pipeline import engine as pe
-from nipype.utils.filemanip import fname_presuffix, copyfile
+from nipype.utils.filemanip import fname_presuffix, copyfile, ensure_list
 from nilearn.image import load_img
 
 from niworkflows.interfaces.masks import ROIsPlot
 
 from ..util import init_bold_reference_wf
+
+# Multi-echo datasets
+bold_datasets = ["""\
+ds000210/sub-06_task-rest_run-01_echo-1_bold.nii.gz
+ds000210/sub-06_task-rest_run-01_echo-2_bold.nii.gz
+ds000210/sub-06_task-rest_run-01_echo-3_bold.nii.gz\
+""".splitlines(), """\
+ds000216/sub-03_task-rest_echo-1_bold.nii.gz
+ds000216/sub-03_task-rest_echo-2_bold.nii.gz
+ds000216/sub-03_task-rest_echo-3_bold.nii.gz
+ds000216/sub-03_task-rest_echo-4_bold.nii.gz""".splitlines()]
+
+# Single-echo datasets
+bold_datasets += """\
+ds000116/sub-12_task-visualoddballwithbuttonresponsetotargetstimuli_run-02_bold.nii.gz
+ds000133/sub-06_ses-post_task-rest_run-01_bold.nii.gz
+ds000140/sub-32_task-heatpainwithregulationandratings_run-02_bold.nii.gz
+ds000157/sub-23_task-passiveimageviewing_bold.nii.gz
+ds000237/sub-03_task-MemorySpan_acq-multiband_run-01_bold.nii.gz
+ds000237/sub-06_task-MemorySpan_acq-multiband_run-01_bold.nii.gz
+ds001240/sub-26_task-localizerimagination_bold.nii.gz
+ds001240/sub-26_task-localizerviewing_bold.nii.gz
+ds001240/sub-26_task-molencoding_run-01_bold.nii.gz
+ds001240/sub-26_task-molencoding_run-02_bold.nii.gz
+ds001240/sub-26_task-molretrieval_run-01_bold.nii.gz
+ds001240/sub-26_task-molretrieval_run-02_bold.nii.gz
+ds001240/sub-26_task-rest_bold.nii.gz
+ds001362/sub-01_task-taskname_run-01_bold.nii.gz""".splitlines()
+
+bold_datasets = [ensure_list(d) for d in bold_datasets]
 
 
 def symmetric_overlap(img1, img2):
@@ -32,43 +62,23 @@ def symmetric_overlap(img1, img2):
     "input_fname,expected_fname",
     [
         (
-            os.path.join(os.getenv("FMRIPREP_REGRESSION_SOURCE", ""), base_fname),
+            [os.path.join(os.getenv("FMRIPREP_REGRESSION_SOURCE", ""), bf)
+             for bf in base_fname],
             fname_presuffix(
-                base_fname,
+                base_fname[0].replace("_echo-1", ""),
                 suffix="_mask",
                 use_ext=True,
                 newpath=os.path.join(
                     os.getenv("FMRIPREP_REGRESSION_TARGETS", ""),
-                    os.path.dirname(base_fname),
+                    os.path.dirname(base_fname[0]),
                 ),
             ),
         )
-        for base_fname in """\
-ds000116/sub-12_task-visualoddballwithbuttonresponsetotargetstimuli_run-02_bold.nii.gz
-ds000133/sub-06_ses-post_task-rest_run-01_bold.nii.gz
-ds000140/sub-32_task-heatpainwithregulationandratings_run-02_bold.nii.gz
-ds000157/sub-23_task-passiveimageviewing_bold.nii.gz
-ds000210/sub-06_task-rest_run-01_echo-1_bold.nii.gz
-ds000210/sub-06_task-rest_run-01_echo-2_bold.nii.gz
-ds000210/sub-06_task-rest_run-01_echo-3_bold.nii.gz
-ds000216/sub-03_task-rest_echo-1_bold.nii.gz
-ds000216/sub-03_task-rest_echo-2_bold.nii.gz
-ds000216/sub-03_task-rest_echo-3_bold.nii.gz
-ds000216/sub-03_task-rest_echo-4_bold.nii.gz
-ds000237/sub-03_task-MemorySpan_acq-multiband_run-01_bold.nii.gz
-ds000237/sub-06_task-MemorySpan_acq-multiband_run-01_bold.nii.gz
-ds001240/sub-26_task-localizerimagination_bold.nii.gz
-ds001240/sub-26_task-localizerviewing_bold.nii.gz
-ds001240/sub-26_task-molencoding_run-01_bold.nii.gz
-ds001240/sub-26_task-molencoding_run-02_bold.nii.gz
-ds001240/sub-26_task-molretrieval_run-01_bold.nii.gz
-ds001240/sub-26_task-molretrieval_run-02_bold.nii.gz
-ds001240/sub-26_task-rest_bold.nii.gz
-ds001362/sub-01_task-taskname_run-01_bold.nii.gz""".splitlines()
+        for base_fname in bold_datasets
     ],
 )
 def test_masking(input_fname, expected_fname):
-    basename = Path(input_fname).name
+    basename = Path(input_fname[0]).name
     dsname = Path(expected_fname).parent.name
 
     # Reconstruct base_fname from above
@@ -76,8 +86,10 @@ def test_masking(input_fname, expected_fname):
     newpath = reports_dir / dsname
 
     name = basename.rstrip("_bold.nii.gz").replace("-", "_")
-    bold_reference_wf = init_bold_reference_wf(omp_nthreads=1, name=name)
-    bold_reference_wf.inputs.inputnode.bold_file = input_fname
+    bold_reference_wf = init_bold_reference_wf(omp_nthreads=1, name=name,
+                                               multiecho=len(input_fname) > 1)
+    bold_reference_wf.inputs.inputnode.bold_file = input_fname[0] if len(input_fname) == 1 \
+        else input_fname
     base_dir = os.getenv("CACHED_WORK_DIRECTORY")
     if base_dir:
         base_dir = Path(base_dir) / dsname
@@ -85,7 +97,7 @@ def test_masking(input_fname, expected_fname):
         bold_reference_wf.base_dir = str(base_dir)
 
     out_fname = fname_presuffix(
-        basename, suffix="_mask.svg", use_ext=False, newpath=str(newpath)
+        Path(expected_fname).name, suffix=".svg", use_ext=False, newpath=str(newpath)
     )
     newpath.mkdir(parents=True, exist_ok=True)
 
@@ -117,7 +129,7 @@ def test_masking(input_fname, expected_fname):
     mask_dir.mkdir(parents=True, exist_ok=True)
     copyfile(
         combine_masks.result.outputs.out_file,
-        fname_presuffix(basename, suffix="_mask", use_ext=True, newpath=str(mask_dir)),
+        str(mask_dir / Path(expected_fname).name),
         copy=True,
     )
 

--- a/niworkflows/func/tests/test_util.py
+++ b/niworkflows/func/tests/test_util.py
@@ -5,9 +5,10 @@ from pathlib import Path
 
 import numpy as np
 from nipype.pipeline import engine as pe
-from nipype.utils.filemanip import fname_presuffix, copyfile, ensure_list
+from nipype.utils.filemanip import fname_presuffix, copyfile
 from nilearn.image import load_img
 
+from ...utils.connections import listify
 from niworkflows.interfaces.masks import ROIsPlot
 
 from ..util import init_bold_reference_wf
@@ -40,7 +41,7 @@ ds001240/sub-26_task-molretrieval_run-02_bold.nii.gz
 ds001240/sub-26_task-rest_bold.nii.gz
 ds001362/sub-01_task-taskname_run-01_bold.nii.gz""".splitlines()
 
-bold_datasets = [ensure_list(d) for d in bold_datasets]
+bold_datasets = [listify(d) for d in bold_datasets]
 
 
 def symmetric_overlap(img1, img2):

--- a/niworkflows/func/util.py
+++ b/niworkflows/func/util.py
@@ -6,7 +6,6 @@ from pkg_resources import resource_filename as pkgr_fn
 
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu, fsl, afni
-from nipype.utils.filemanip import ensure_list
 
 from templateflow.api import get as get_template
 
@@ -21,6 +20,7 @@ from ..interfaces.images import ValidateImage, MatchHeader
 from ..interfaces.masks import SimpleShowMaskRPT
 from ..interfaces.registration import EstimateReferenceImage
 from ..interfaces.utils import CopyXForm
+from ..utils.connections import listify
 from ..utils.misc import pass_dummy_scans as _pass_dummy_scans
 
 
@@ -176,7 +176,7 @@ methodology of *fMRIPrep*.
 
     # fmt: off
     workflow.connect([
-        (inputnode, val_bold, [(("bold_file", ensure_list), "in_file")]),
+        (inputnode, val_bold, [(("bold_file", listify), "in_file")]),
         (inputnode, enhance_and_skullstrip_bold_wf, [
             ("bold_mask", "inputnode.pre_mask"),
         ]),
@@ -185,7 +185,7 @@ methodology of *fMRIPrep*.
         (gen_ref, enhance_and_skullstrip_bold_wf, [
             ("ref_image", "inputnode.in_file"),
         ]),
-        (val_bold, bold_1st, [(("out_file", ensure_list), "inlist")]),
+        (val_bold, bold_1st, [(("out_file", listify), "inlist")]),
         (gen_ref, calc_dummy_scans, [("n_volumes_to_discard", "algo_dummy_scans")]),
         (calc_dummy_scans, outputnode, [("skip_vols_num", "skip_vols")]),
         (gen_ref, outputnode, [
@@ -197,7 +197,7 @@ methodology of *fMRIPrep*.
             ("outputnode.mask_file", "bold_mask"),
             ("outputnode.skull_stripped_file", "ref_image_brain"),
         ]),
-        (val_bold, validate_1st, [(("out_report", ensure_list), "inlist")]),
+        (val_bold, validate_1st, [(("out_report", listify), "inlist")]),
         (bold_1st, outputnode, [("out", "bold_file")]),
         (validate_1st, outputnode, [("out", "validation_report")]),
     ])
@@ -218,7 +218,7 @@ methodology of *fMRIPrep*.
         )
         # fmt: off
         workflow.connect([
-            (inputnode, val_sbref, [(("sbref_file", ensure_list), "in_file")]),
+            (inputnode, val_sbref, [(("sbref_file", listify), "in_file")]),
             (val_sbref, gen_ref, [("out_file", "sbref_file")]),
         ])
         # fmt: on

--- a/niworkflows/func/util.py
+++ b/niworkflows/func/util.py
@@ -6,6 +6,7 @@ from pkg_resources import resource_filename as pkgr_fn
 
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu, fsl, afni
+from nipype.utils.filemanip import ensure_list
 
 from templateflow.api import get as get_template
 
@@ -163,8 +164,8 @@ using a custom methodology of *fMRIPrep*.
         (inputnode, enhance_and_skullstrip_bold_wf, [
             ("bold_mask", "inputnode.pre_mask"),
         ]),
-        (inputnode, validate, [("bold_file", "in_file")]),
-        (inputnode, gen_ref, [("sbref_file", "sbref_file")]),
+        (inputnode, validate, [(("bold_file", ensure_list), "in_file")]),
+        (inputnode, gen_ref, [(("sbref_file", ensure_list), "sbref_file")]),
         (inputnode, calc_dummy_scans, [("dummy_scans", "dummy_scans")]),
         (validate, gen_ref, [("out_file", "in_file")]),
         (gen_ref, enhance_and_skullstrip_bold_wf, [

--- a/niworkflows/func/util.py
+++ b/niworkflows/func/util.py
@@ -165,7 +165,7 @@ using a custom methodology of *fMRIPrep*.
             ("bold_mask", "inputnode.pre_mask"),
         ]),
         (inputnode, validate, [(("bold_file", ensure_list), "in_file")]),
-        (inputnode, gen_ref, [(("sbref_file", ensure_list), "sbref_file")]),
+        (inputnode, gen_ref, [("sbref_file", "sbref_file")]),
         (inputnode, calc_dummy_scans, [("dummy_scans", "dummy_scans")]),
         (validate, gen_ref, [("out_file", "in_file")]),
         (gen_ref, enhance_and_skullstrip_bold_wf, [

--- a/niworkflows/func/util.py
+++ b/niworkflows/func/util.py
@@ -20,7 +20,7 @@ from ..interfaces.images import ValidateImage, MatchHeader
 from ..interfaces.masks import SimpleShowMaskRPT
 from ..interfaces.registration import EstimateReferenceImage
 from ..interfaces.utils import CopyXForm
-from ..utils.misc import pass_dummy_scans as _pass_dummy_scans
+from ..utils.misc import select_first, pass_dummy_scans as _pass_dummy_scans
 
 
 DEFAULT_MEMORY_MIN_GB = 0.01
@@ -125,6 +125,7 @@ using a custom methodology of *fMRIPrep*.
                 "ref_image_brain",
                 "bold_mask",
                 "validation_report",
+                "mask_report",
             ]
         ),
         name="outputnode",
@@ -134,7 +135,12 @@ using a custom methodology of *fMRIPrep*.
     if bold_file is not None:
         inputnode.inputs.bold_file = bold_file
 
-    validate = pe.Node(ValidateImage(), name="validate", mem_gb=DEFAULT_MEMORY_MIN_GB)
+    validate = pe.MapNode(
+        ValidateImage(),
+        name="validate",
+        mem_gb=DEFAULT_MEMORY_MIN_GB,
+        iterfield=["in_file"],
+    )
 
     gen_ref = pe.Node(
         EstimateReferenceImage(), name="gen_ref", mem_gb=1
@@ -165,7 +171,7 @@ using a custom methodology of *fMRIPrep*.
             ("ref_image", "inputnode.in_file"),
         ]),
         (validate, outputnode, [
-            ("out_file", "bold_file"),
+            (("out_file", select_first), "bold_file"),
             ("out_report", "validation_report"),
         ]),
         (gen_ref, calc_dummy_scans, [("n_volumes_to_discard", "algo_dummy_scans")]),

--- a/niworkflows/func/util.py
+++ b/niworkflows/func/util.py
@@ -159,7 +159,7 @@ using a custom methodology of *fMRIPrep*.
         )
 
     gen_ref = pe.Node(
-        EstimateReferenceImage(), name="gen_ref", mem_gb=1
+        EstimateReferenceImage(multiecho=multiecho), name="gen_ref", mem_gb=1
     )  # OE: 128x128x128x50 * 64 / 8 ~ 900MB.
     enhance_and_skullstrip_bold_wf = init_enhance_and_skullstrip_bold_wf(
         brainmask_thresh=brainmask_thresh,
@@ -185,6 +185,10 @@ using a custom methodology of *fMRIPrep*.
         (gen_ref, enhance_and_skullstrip_bold_wf, [
             ("ref_image", "inputnode.in_file"),
         ]),
+        (validate, outputnode, [
+            (("out_file", select_first), "bold_file"),
+            ("out_report", "validation_report"),
+        ]),
         (gen_ref, calc_dummy_scans, [("n_volumes_to_discard", "algo_dummy_scans")]),
         (calc_dummy_scans, outputnode, [("skip_vols_num", "skip_vols")]),
         (gen_ref, outputnode, [
@@ -201,14 +205,10 @@ using a custom methodology of *fMRIPrep*.
     if multiecho:
         workflow.connect([
             (inputnode, validate, [(("bold_file", ensure_list), "in_file")]),
-            (validate, outputnode, [(("out_file", select_first), "bold_file"),
-                                    ("out_report", "validation_report")]),
         ])
     else:
         workflow.connect([
             (inputnode, validate, [("bold_file", "in_file")]),
-            (validate, outputnode, [("out_file", "bold_file"),
-                                    ("out_report", "validation_report")]),
         ])
     # fmt: on
 

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -424,6 +424,14 @@ class _EstimateReferenceImageInputSpec(BaseInterfaceInputSpec):
         usedefault=True,
         desc="Which software to use to perform motion correction",
     )
+    multiecho = traits.Bool(
+        False,
+        usedefault=True,
+        desc=(
+            "If multiecho data was supplied, data from "
+            "the first echo will be selected."
+        ),
+    )
 
 
 class _EstimateReferenceImageOutputSpec(TraitedSpec):

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -399,9 +399,8 @@ class ResampleBeforeAfterRPT(SimpleBeforeAfterRPT):
 
 
 class _EstimateReferenceImageInputSpec(BaseInterfaceInputSpec):
-    in_file = traits.Either(
+    in_file = InputMultiPath(
         File(exists=True),
-        InputMultiPath(File(exists=True)),
         mandatory=True,
         desc=(
             "4D EPI file. If multiple files "
@@ -410,9 +409,8 @@ class _EstimateReferenceImageInputSpec(BaseInterfaceInputSpec):
             "from the same run."
         ),
     )
-    sbref_file = traits.Either(
+    sbref_file = InputMultiPath(
         File(exists=True),
-        InputMultiPath(File(exists=True)),
         desc=(
             "Single band reference image. "
             "If multiple files are provided, "
@@ -450,10 +448,7 @@ class EstimateReferenceImage(SimpleInterface):
 
     def _run_interface(self, runtime):
         # Select first EPI file
-        if not isinstance(self.inputs.in_file, File):
-            ref_name = self.inputs.in_file[0]
-        else:
-            ref_name = self.inputs.in_file
+        ref_name = self.inputs.in_file[0]
         ref_nii = nb.load(ref_name)
         n_volumes_to_discard = _get_vols_to_discard(ref_nii)
 
@@ -462,10 +457,7 @@ class EstimateReferenceImage(SimpleInterface):
         out_ref_fname = os.path.join(runtime.cwd, "ref_bold.nii.gz")
         if isdefined(self.inputs.sbref_file):
             # Select first SBRef file
-            if not isinstance(self.inputs.sbref_file, File):
-                ref_name = self.inputs.sbref_file[0]
-            else:
-                ref_name = self.inputs.sbref_file
+            ref_name = self.inputs.sbref_file[0]
             ref_nii = nb.squeeze_image(nb.load(ref_name))
             out_ref_fname = os.path.join(runtime.cwd, "ref_sbref.nii.gz")
 

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -435,9 +435,6 @@ class _EstimateReferenceImageOutputSpec(TraitedSpec):
         "state volumes in the beginning of "
         "the input file"
     )
-    description = traits.Str(
-        desc="Description of reference image " "identification steps taken."
-    )
 
 
 class EstimateReferenceImage(SimpleInterface):

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -462,13 +462,13 @@ class EstimateReferenceImage(SimpleInterface):
 
         self._results["n_volumes_to_discard"] = n_volumes_to_discard
 
-        if multiecho and (len(self.inputs.in_file) < 2):
+        if self.inputs.multiecho and (len(self.inputs.in_file) < 2):
             raise ValueError("Argument 'multiecho' is True but "
                              "'in_file' has only one element")
 
         out_ref_fname = os.path.join(runtime.cwd, "ref_bold.nii.gz")
         if isdefined(self.inputs.sbref_file):
-            if multiecho and (len(self.inputs.sbref_file) < 2):
+            if self.inputs.multiecho and (len(self.inputs.sbref_file) < 2):
                 raise ValueError("Argument 'multiecho' is True but "
                                  "'sbref_file' has only one element")
 

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -462,8 +462,16 @@ class EstimateReferenceImage(SimpleInterface):
 
         self._results["n_volumes_to_discard"] = n_volumes_to_discard
 
+        if multiecho and (len(self.inputs.in_file) < 2):
+            raise ValueError("Argument 'multiecho' is True but "
+                             "'in_file' has only one element")
+
         out_ref_fname = os.path.join(runtime.cwd, "ref_bold.nii.gz")
         if isdefined(self.inputs.sbref_file):
+            if multiecho and (len(self.inputs.sbref_file) < 2):
+                raise ValueError("Argument 'multiecho' is True but "
+                                 "'sbref_file' has only one element")
+
             # Select first SBRef file
             ref_name = self.inputs.sbref_file[0]
             ref_nii = nb.squeeze_image(nb.load(ref_name))

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -16,7 +16,7 @@ from nipype.interfaces.base import (
     BaseInterfaceInputSpec,
     File,
     SimpleInterface,
-    InputMultiPath,
+    InputMultiObject,
 )
 from nipype.interfaces.mixins import reporting
 from nipype.interfaces import freesurfer as fs
@@ -399,7 +399,7 @@ class ResampleBeforeAfterRPT(SimpleBeforeAfterRPT):
 
 
 class _EstimateReferenceImageInputSpec(BaseInterfaceInputSpec):
-    in_file = InputMultiPath(
+    in_file = InputMultiObject(
         File(exists=True),
         mandatory=True,
         desc=(
@@ -409,7 +409,7 @@ class _EstimateReferenceImageInputSpec(BaseInterfaceInputSpec):
             "from the same run."
         ),
     )
-    sbref_file = InputMultiPath(
+    sbref_file = InputMultiObject(
         File(exists=True),
         desc=(
             "Single band reference image. "

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -8,7 +8,7 @@ import nibabel as nb
 import numpy as np
 from nilearn import image as nli
 from nilearn.image import index_img
-from nipype.utils.filemanip import fname_presuffix, ensure_list
+from nipype.utils.filemanip import fname_presuffix
 from nipype.interfaces.base import (
     traits,
     isdefined,
@@ -467,9 +467,7 @@ class EstimateReferenceImage(SimpleInterface):
 
     def _run_interface(self, runtime):
         is_sbref = isdefined(self.inputs.sbref_file)
-        ref_input = ensure_list(
-            self.inputs.sbref_file if is_sbref else self.inputs.in_file
-        )
+        ref_input = self.inputs.sbref_file if is_sbref else self.inputs.in_file
 
         if self.inputs.multiecho:
             if len(ref_input) < 2:

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -8,7 +8,7 @@ import nibabel as nb
 import numpy as np
 from nilearn import image as nli
 from nilearn.image import index_img
-from nipype.utils.filemanip import fname_presuffix
+from nipype.utils.filemanip import fname_presuffix, ensure_list
 from nipype.interfaces.base import (
     traits,
     isdefined,
@@ -445,61 +445,84 @@ class _EstimateReferenceImageOutputSpec(TraitedSpec):
 
 class EstimateReferenceImage(SimpleInterface):
     """
-    Given an 4D EPI file estimate an optimal reference image that could be later
-    used for motion estimation and coregistration purposes. If detected uses
-    T1 saturated volumes (non-steady state) otherwise a median of
+    Generate a reference 3D map from BOLD and SBRef EPI images for BOLD datasets.
+
+    Given a 4D BOLD file or one or more 3/4D SBRefs, estimate a reference
+    image for subsequent motion estimation and coregistration steps.
+    For the case of BOLD datasets, it estimates a number of T1w saturated volumes
+    (non-steady state at the beginning of the scan) and calculates the median
+    across them.
+    Otherwise (SBRefs or detected zero non-steady state frames), a median of
     of a subset of motion corrected volumes is used.
+    If the input reference (BOLD or SBRef) is 3D already, it just returns a
+    copy of the image with the NIfTI header extensions removed.
+
+    LIMITATION: If one wants to extract the reference from several SBRefs
+    with several echoes each, the first echo should be selected elsewhere
+    and run this interface in ``multiecho = False`` mode.
     """
 
     input_spec = _EstimateReferenceImageInputSpec
     output_spec = _EstimateReferenceImageOutputSpec
 
     def _run_interface(self, runtime):
-        # Select first EPI file
-        ref_name = self.inputs.in_file[0]
-        ref_nii = nb.load(ref_name)
-        n_volumes_to_discard = _get_vols_to_discard(ref_nii)
+        is_sbref = isdefined(self.inputs.sbref_file)
+        ref_input = ensure_list(
+            self.inputs.sbref_file if is_sbref else self.inputs.in_file
+        )
 
-        self._results["n_volumes_to_discard"] = n_volumes_to_discard
-
-        if self.inputs.multiecho and (len(self.inputs.in_file) < 2):
-            raise ValueError("Argument 'multiecho' is True but "
-                             "'in_file' has only one element")
-
-        out_ref_fname = os.path.join(runtime.cwd, "ref_bold.nii.gz")
-        if isdefined(self.inputs.sbref_file):
-            if self.inputs.multiecho and (len(self.inputs.sbref_file) < 2):
+        if self.inputs.multiecho:
+            if len(ref_input) < 2:
+                input_name = "sbref_file" if is_sbref else "in_file"
                 raise ValueError("Argument 'multiecho' is True but "
-                                 "'sbref_file' has only one element")
+                                 f"'{input_name}' has only one element.")
+            else:
+                # Select only the first echo (see LIMITATION above for SBRefs)
+                ref_input = ref_input[:1]
+        elif not is_sbref and len(ref_input) > 1:
+            raise ValueError("Input 'in_file' cannot point to more than one file "
+                             "for single-echo BOLD datasets.")
 
-            # Select first SBRef file
-            ref_name = self.inputs.sbref_file[0]
-            ref_nii = nb.squeeze_image(nb.load(ref_name))
+        # Build the nibabel spatial image we will work with
+        ref_im = []
+        for im_i in ref_input:
+            nib_i = nb.squeeze_image(nb.load(im_i))
+            if nib_i.dataobj.ndim == 3:
+                ref_im.append(nib_i)
+            elif nib_i.dataobj.ndim == 4:
+                ref_im += nb.four_to_three(nib_i)
+        ref_im = nb.squeeze_image(nb.concat_images(ref_im))
+
+        # Volumes to discard only makes sense with BOLD inputs.
+        if not is_sbref:
+            n_volumes_to_discard = _get_vols_to_discard(ref_im)
+            out_ref_fname = os.path.join(runtime.cwd, "ref_bold.nii.gz")
+        else:
+            n_volumes_to_discard = 0
             out_ref_fname = os.path.join(runtime.cwd, "ref_sbref.nii.gz")
 
-            # If reference is only 1 volume, return it directly
-            if len(ref_nii.shape) == 3:
-                ref_nii.header.extensions.clear()
-                ref_nii.to_filename(out_ref_fname)
-                self._results["ref_image"] = out_ref_fname
-                return runtime
-            else:
-                # Reset this variable as it no longer applies
-                # and value for the output is stored in self._results
-                n_volumes_to_discard = 0
+        # Set interface outputs
+        self._results["n_volumes_to_discard"] = n_volumes_to_discard
+        self._results["ref_image"] = out_ref_fname
 
         # Slicing may induce inconsistencies with shape-dependent values in extensions.
         # For now, remove all. If this turns out to be a mistake, we can select extensions
         # that don't break pipeline stages.
-        ref_nii.header.extensions.clear()
+        ref_im.header.extensions.clear()
+
+        # If reference is only 1 volume, return it directly
+        if ref_im.dataobj.ndim == 3:
+            ref_im.to_filename(out_ref_fname)
+            return runtime
 
         if n_volumes_to_discard == 0:
-            if ref_nii.shape[-1] > 40:
-                ref_name = os.path.join(runtime.cwd, "slice.nii.gz")
-                nb.Nifti1Image(
-                    ref_nii.dataobj[:, :, :, 20:40], ref_nii.affine, ref_nii.header
-                ).to_filename(ref_name)
+            if ref_im.shape[-1] > 40:
+                ref_im = nb.Nifti1Image(
+                    ref_im.dataobj[:, :, :, 20:40], ref_im.affine, ref_im.header
+                )
 
+            ref_name = os.path.join(runtime.cwd, "slice.nii.gz")
+            ref_im.to_filename(ref_name)
             if self.inputs.mc_method == "AFNI":
                 res = afni.Volreg(
                     in_file=ref_name,
@@ -516,14 +539,12 @@ class EstimateReferenceImage(SimpleInterface):
             median_image_data = np.median(mc_slice_nii.get_fdata(), axis=3)
         else:
             median_image_data = np.median(
-                ref_nii.dataobj[:, :, :, :n_volumes_to_discard], axis=3
+                ref_im.dataobj[:, :, :, :n_volumes_to_discard], axis=3
             )
 
-        nb.Nifti1Image(median_image_data, ref_nii.affine, ref_nii.header).to_filename(
+        nb.Nifti1Image(median_image_data, ref_im.affine, ref_im.header).to_filename(
             out_ref_fname
         )
-
-        self._results["ref_image"] = out_ref_fname
         return runtime
 
 

--- a/niworkflows/utils/connections.py
+++ b/niworkflows/utils/connections.py
@@ -1,0 +1,58 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+"""
+Utilities for the creation of nipype workflows.
+
+Because these functions are meant to be inlined in nipype's ``connect`` invocations,
+all the imports MUST be done in each function's context.
+
+"""
+
+__all__ = [
+    "listify",
+    "pop_file",
+]
+
+
+def pop_file(in_files):
+    """
+    Select the first file from a list of filenames.
+
+    Used to grab the first echo's file when processing
+    multi-echo data through workflows that only accept
+    a single file.
+
+    Examples
+    --------
+    >>> pop_file('some/file.nii.gz')
+    'some/file.nii.gz'
+    >>> pop_file(['some/file1.nii.gz', 'some/file2.nii.gz'])
+    'some/file1.nii.gz'
+
+    """
+    if isinstance(in_files, (list, tuple)):
+        return in_files[0]
+    return in_files
+
+
+def listify(value):
+    """
+    Convert to a list (inspired by bids.utils.listify).
+
+    Examples
+    --------
+    >>> listify('some/file.nii.gz')
+    ['some/file.nii.gz']
+    >>> listify((0.1, 0.2))
+    [0.1, 0.2]
+    >>> listify(None) is None
+    True
+
+    """
+    from pathlib import Path
+    from nipype.interfaces.base import isdefined
+    if not isdefined(value) or isinstance(value, type(None)):
+        return value
+    if isinstance(value, (str, bytes, Path)):
+        return [str(value)]
+    return list(value)

--- a/niworkflows/utils/misc.py
+++ b/niworkflows/utils/misc.py
@@ -212,6 +212,19 @@ def splitext(fname):
     return stem, basename[len(stem):]
 
 
+def select_first(in_files):
+    """
+    Select the first file from a list of filenames.
+    Used to grab the first echo's file when processing
+    multi-echo data through workflows that only accept
+    a single file.
+    """
+    if isinstance(in_files, list):
+        return in_files[0]
+    else:
+        return in_files
+
+
 def _copy_any(src, dst):
     import os
     import gzip

--- a/niworkflows/utils/misc.py
+++ b/niworkflows/utils/misc.py
@@ -218,6 +218,12 @@ def select_first(in_files):
     Used to grab the first echo's file when processing
     multi-echo data through workflows that only accept
     a single file.
+
+    >>> select_first('some/file.nii.gz')
+    'some/file.nii.gz'
+    >>> select_first(['some/file1.nii.gz', 'some/file2.nii.gz'])
+    'some/file1.nii.gz'
+
     """
     if isinstance(in_files, list):
         return in_files[0]

--- a/niworkflows/utils/misc.py
+++ b/niworkflows/utils/misc.py
@@ -212,27 +212,6 @@ def splitext(fname):
     return stem, basename[len(stem):]
 
 
-def select_first(in_files):
-    """
-    Select the first file from a list of filenames.
-
-    Used to grab the first echo's file when processing
-    multi-echo data through workflows that only accept
-    a single file.
-
-    Examples
-    --------
-    >>> select_first('some/file.nii.gz')
-    'some/file.nii.gz'
-    >>> select_first(['some/file1.nii.gz', 'some/file2.nii.gz'])
-    'some/file1.nii.gz'
-
-    """
-    if isinstance(in_files, (list, tuple)):
-        return in_files[0]
-    return in_files
-
-
 def _copy_any(src, dst):
     import os
     import gzip

--- a/niworkflows/utils/misc.py
+++ b/niworkflows/utils/misc.py
@@ -215,10 +215,13 @@ def splitext(fname):
 def select_first(in_files):
     """
     Select the first file from a list of filenames.
+
     Used to grab the first echo's file when processing
     multi-echo data through workflows that only accept
     a single file.
 
+    Examples
+    --------
     >>> select_first('some/file.nii.gz')
     'some/file.nii.gz'
     >>> select_first(['some/file1.nii.gz', 'some/file2.nii.gz'])
@@ -227,8 +230,7 @@ def select_first(in_files):
     """
     if isinstance(in_files, (list, tuple)):
         return in_files[0]
-    else:
-        return in_files
+    return in_files
 
 
 def _copy_any(src, dst):

--- a/niworkflows/utils/misc.py
+++ b/niworkflows/utils/misc.py
@@ -225,7 +225,7 @@ def select_first(in_files):
     'some/file1.nii.gz'
 
     """
-    if isinstance(in_files, list):
+    if isinstance(in_files, (list, tuple)):
         return in_files[0]
     else:
         return in_files


### PR DESCRIPTION
Closes #399. 

This PR allows `bold_reference_wf` to accept multiple BOLD and/or SBRef files, under the assumption that multiple files reflect multiple echoes from the same run. It currently just selects the first image from each for use, but could be extended to use information from multiple echoes for reference image generation.

The workflow still returns just one BOLD file, since a number of workflows take the BOLD file stored in the output node as their inputs, and they are not currently set up to work with multi-echo data. To that end I also added a function to `utils.misc` to select the first item in a list.

These changes shouldn't impact behavior at all, but there will need to be a corresponding PR in fMRIPrep in order to feed multi-echo data and SBRefs into the reference image workflow, when available.