### PR TITLE
MAINT: Fix test_masks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ version: 2
 jobs:
   build:
     machine:
-      image: circleci/classic:201711-01
+      image: circleci/classic:201808-01
     working_directory: /tmp/src/niworkflows
     environment:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"
@@ -98,7 +98,7 @@ jobs:
   get_data:
     machine:
       # Ubuntu 14.04 with Docker 17.10.0-ce
-      image: circleci/classic:201711-01
+      image: circleci/classic:201808-01
     working_directory: /home/circleci/data
     steps:
       - restore_cache:
@@ -146,7 +146,7 @@ jobs:
   get_regression_data:
     machine:
       # Ubuntu 14.04 with Docker 17.10.0-ce
-      image: circleci/classic:201711-01
+      image: circleci/classic:201808-01
     working_directory: /home/circleci/data
     steps:
       - restore_cache:
@@ -181,7 +181,7 @@ jobs:
 
   test_pytest:
     machine:
-      image: circleci/classic:201711-01
+      image: circleci/classic:201808-01
     working_directory: /tmp/tests
     steps:
       - attach_workspace:
@@ -267,7 +267,7 @@ jobs:
 
   test_masks:
     machine:
-      image: circleci/classic:201711-01
+      image: circleci/classic:201808-01
     working_directory: /tmp/masks
     steps:
       - attach_workspace:
@@ -289,41 +289,60 @@ jobs:
       - restore_cache:
           keys:
             - regression-v2-{{ .Revision }}
-
-      - checkout:
-          path: /tmp/src/niworkflows
-      - run:
-          name: Set PR number
-          command: |
-            echo 'export CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"' >> $BASH_ENV
-            source $BASH_ENV
-            echo $CIRCLE_PR_NUMBER
-      - run:
-          name: Get codecov
-          command: python -m pip install codecov
-
+      - restore_cache:
+          keys:
+            - masks-workdir-v1-{{ .Branch }}-{{epoch}}
+            - masks-workdir-v1-{{ .Branch }}-
+            - masks-workdir-v1-master-
+            - masks-workdir-v1-
       - run:
           name: Run regression tests on EPI masks
           no_output_timeout: 2h
           command: |
-            mkdir -p /tmp/masks/reports && \
-            docker run -ti --rm=false  -w /src/niworkflows \
-              -e COVERAGE_FILE=/tmp/masks/.coverage \
-              -v /tmp/data:/tmp/data -v /tmp/masks:/tmp/masks \
+            mkdir -p /tmp/masks/{reports,workdir} && \
+            docker run -ti -u $(id -u) -w /src/niworkflows \
+              -e COVERAGE_FILE=/tmp/masks/reports/.coverage \
+              -v /tmp/data:/tmp/data -v /tmp/masks/reports:/tmp/masks/reports \
               -e FMRIPREP_REGRESSION_SOURCE=/tmp/data/fmriprep_bold_truncated \
               -e FMRIPREP_REGRESSION_TARGETS=/tmp/data/fmriprep_bold_mask \
               -e FMRIPREP_REGRESSION_REPORTS=/tmp/masks/reports \
+              -e CACHED_WORK_DIRECTORY=/tmp/work -v /tmp/masks/workdir:/tmp/work \
               niworkflows:latest \
-              pytest --junit-xml=/tmp/masks/regression.xml \
-                     --cov niworkflows --cov-report xml:/tmp/masks/coverage.xml \
+              coverage run -p --rcfile=setup.cfg \
+                     -m pytest --junit-xml=/tmp/masks/reports/regression.xml \
                      niworkflows/func/tests/
+      - save_cache:
+         key: masks-workdir-v1-{{ .Branch }}-{{ epoch }}
+         paths:
+            - /tmp/masks/workdir
+      - store_artifacts:
+          path: /tmp/masks/reports
+      - store_test_results:
+          path: /tmp/masks/reports
 
       - run:
-          name: Submit masks test coverage
+          name: Coverage preparation
           command: |
-            python -m codecov --file /tmp/masks/coverage.xml --root /tmp/src/niworkflows \
-                --flags masks -e CIRCLE_JOB
-
+            docker run -ti -u $(id -u) -w /tmp/masks/reports \
+              -e COVERAGE_FILE=/tmp/masks/reports/.coverage \
+              -v /tmp/masks/reports:/tmp/masks/reports \
+              niworkflows:latest coverage combine
+            docker run -ti -u $(id -u) -w /tmp/masks/reports \
+              -e COVERAGE_FILE=/tmp/masks/reports/.coverage \
+              -v /tmp/masks/reports:/tmp/masks/reports \
+              niworkflows:latest coverage xml -o coverage.xml
+      - checkout:
+          path: /tmp/src/niworkflows
+      - run:
+          name: Get codecov
+          command: python -m pip install codecov
+      - run:
+          name: Submit masks test coverage
+          working_directory: /tmp/src/niworkflows
+          command: |
+            cp /tmp/masks/reports/coverage.xml .
+            sed -i "s+/src/niworkflows+/tmp/src/niworkflows+g" coverage.xml
+            python -m codecov --file coverage.xml --flags masks -e CIRCLE_JOB
       - run:
           name: Package new masks
           when: always
@@ -331,16 +350,12 @@ jobs:
           working_directory: /tmp/data
           command: |
             tar cfz /tmp/masks/fmriprep_bold_mask.tar.gz fmriprep_bold_mask/*/*.nii.gz
-
       - store_artifacts:
-          path: /tmp/masks
-
-      - store_test_results:
-          path: /tmp/masks
+          path: /tmp/masks/fmriprep_bold_mask.tar.gz
 
   test_package:
     machine:
-      image: circleci/classic:201711-01
+      image: circleci/classic:201808-01
     working_directory: /tmp/src/niworkflows
     steps:
       - checkout
@@ -365,7 +380,7 @@ jobs:
 
   deploy:
     machine:
-      image: circleci/classic:201711-01
+      image: circleci/classic:201808-01
     working_directory: /tmp/src/niworkflows
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -156,6 +156,7 @@ RUN pip install --no-cache-dir -r requirements.txt && \
 RUN python -c "from templateflow import api as tfapi; \
                tfapi.get(['MNI152Lin', 'MNI152NLin2009cAsym', 'OASIS30ANTs'], suffix='T1w'); \
                tfapi.get(['MNI152Lin', 'MNI152NLin2009cAsym', 'OASIS30ANTs'], desc='brain', suffix='mask'); \
+               tfapi.get(['MNI152NLin2009cAsym'], desc='fMRIPrep', suffix='boldref'); \
                tfapi.get('OASIS30ANTs', resolution=1, desc='4', suffix='dseg'); \
                tfapi.get(['OASIS30ANTs', 'NKI'], resolution=1, label='brain', suffix='probseg'); \
                tfapi.get(['OASIS30ANTs', 'NKI'], resolution=1, desc='BrainCerebellumRegistration', suffix='mask'); "
@@ -164,6 +165,8 @@ COPY . niworkflows/
 WORKDIR /src/niworkflows/
 RUN pip install --no-cache-dir -e .[all] && \
     rm -rf $HOME/.cache/pip
+
+COPY docker/files/nipype.cfg /home/niworkflows/.nipype/nipype.cfg
 
 # Cleanup and ensure perms.
 RUN rm -rf $HOME/.npm $HOME/.conda $HOME/.empty && \

--- a/docker/files/nipype.cfg
+++ b/docker/files/nipype.cfg
@@ -1,0 +1,7 @@
+[execution]
+hash_method = content
+poll_sleep_duration = 0.01
+remove_unnecessary_outputs = true
+crashfile_format = txt
+profile_runtime = false
+use_relative_paths = false

--- a/niworkflows/func/util.py
+++ b/niworkflows/func/util.py
@@ -20,6 +20,7 @@ from ..interfaces.images import ValidateImage, MatchHeader
 from ..interfaces.masks import SimpleShowMaskRPT
 from ..interfaces.registration import EstimateReferenceImage
 from ..interfaces.utils import CopyXForm
+from ..utils.misc import pass_dummy_scans as _pass_dummy_scans
 
 
 DEFAULT_MEMORY_MIN_GB = 0.01
@@ -425,25 +426,3 @@ def init_skullstrip_bold_wf(name='skullstrip_bold_wf'):
     ])
 
     return workflow
-
-
-def _pass_dummy_scans(algo_dummy_scans, dummy_scans=None):
-    """
-    Graft manually provided number of dummy scans, if necessary.
-
-    Parameters
-    ----------
-    algo_dummy_scans : int
-        number of volumes to skip determined by an algorithm
-    dummy_scans : int or None
-        number of volumes to skip determined by the user
-
-    Returns
-    -------
-    skip_vols_num : int
-        number of volumes to skip
-
-    """
-    if dummy_scans is None:
-        return algo_dummy_scans
-    return dummy_scans

--- a/niworkflows/utils/misc.py
+++ b/niworkflows/utils/misc.py
@@ -241,5 +241,27 @@ def clean_directory(path):
     return True
 
 
+def pass_dummy_scans(algo_dummy_scans, dummy_scans=None):
+    """
+    Graft manually provided number of dummy scans, if necessary.
+
+    Parameters
+    ----------
+    algo_dummy_scans : int
+        number of volumes to skip determined by an algorithm
+    dummy_scans : int or None
+        number of volumes to skip determined by the user
+
+    Returns
+    -------
+    skip_vols_num : int
+        number of volumes to skip
+
+    """
+    if dummy_scans is None:
+        return algo_dummy_scans
+    return dummy_scans
+
+
 if __name__ == '__main__':
     pass

--- a/niworkflows/utils/tests/test_misc.py
+++ b/niworkflows/utils/tests/test_misc.py
@@ -1,0 +1,15 @@
+"""Test misc module."""
+import pytest
+from ..misc import pass_dummy_scans
+
+
+@pytest.mark.parametrize('algo_dummy_scans,dummy_scans,expected_out', [
+    (2, 1, 1),
+    (2, None, 2),
+    (2, 0, 0),
+])
+def test_pass_dummy_scans(algo_dummy_scans, dummy_scans, expected_out):
+    """Check dummy scans passing."""
+    skip_vols = pass_dummy_scans(algo_dummy_scans, dummy_scans)
+
+    assert skip_vols == expected_out


### PR DESCRIPTION
This maintenance PR addresses several issues of the `test_masks` build in CircleCI:
- [x] Coverage collection was broken in master - for unknown reasons, problems deriving from parallelism of tests started to creep up.
- [x] Cache the working directory of the masks - it was taking way too much time.
- [x] Split the test on dummy scans to another test-case where it is executed more often.