### PR TITLE
[FIX] update naming patterns in figures.json

### DIFF
--- a/niworkflows/reports/figures.json
+++ b/niworkflows/reports/figures.json
@@ -47,7 +47,7 @@
         },
         {
             "name": "echo",
-            "pattern": "[_/\\\\]echo-([0-9]+)\\_bold."
+            "pattern": "[_/\\\\]echo-([0-9]+)"
         },
         {
             "name": "recording",
@@ -112,7 +112,7 @@
     ],
 
     "default_path_patterns": [
-        "sub-{subject}[/ses-{session}]/{datatype<anat|figures>}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{contrast}][_rec-{reconstruction}][_space-{space}][_desc-{desc}]_{suffix<T1w|T2w|T1rho|T1map|T2map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|inplaneT[12]|angio|dseg|mask>}.{extension<html|svg>}",
+        "sub-{subject}[/ses-{session}]/{datatype<anat|figures>}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_space-{space}][_desc-{desc}]_{suffix<T1w|T2w|T1rho|T1map|T2map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|inplaneT[12]|angio|dseg|mask>}.{extension<html|svg>}",
         "sub-{subject}[/ses-{session}]/{datatype<func|figures>}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_space-{space}][_desc-{desc}]_{suffix<bold>}.{extension<html|svg>}"
     ]
 }


### PR DESCRIPTION
two items that I thought should be changed:
- contrast -> ceagent in the anatomical `default_path_patterns`
- remove _bold from echo pattern, (I'm not sure what the original intention of the pattern was, but the double backslash does not [appear to match a reasonable string](https://regex101.com/r/UQROec/1), and echo is not required to be the last key-value pair in the [`default_path_patterns`](https://github.com/nipreps/niworkflows/blob/bfffaf8ea8e6fe1615be4a24089a5d750bd6e024/niworkflows/reports/figures.json#L116))