### PR TITLE
ENH: Numerical stability of EPI brain-masks using probabilistic prior

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,8 +151,8 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - regression-v3-{{ .Revision }}
-            - regression-v3-
+            - regression-v4-{{ .Revision }}
+            - regression-v4-
       - run:
           name: Get truncated BOLD series
           command: |
@@ -175,7 +175,7 @@ jobs:
               echo "Pre-computed masks were cached"
             fi
       - save_cache:
-         key: regression-v3-{{ .Revision }}-{{ epoch }}
+         key: regression-v4-{{ .Revision }}-{{ epoch }}
          paths:
             - /tmp/data
 
@@ -282,7 +282,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - regression-v3-{{ .Revision }}
+            - regression-v4-{{ .Revision }}
       - restore_cache:
           keys:
             - masks-workdir-v2-{{ .Branch }}-{{epoch}}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,10 +285,10 @@ jobs:
             - regression-v2-{{ .Revision }}
       - restore_cache:
           keys:
-            - masks-workdir-v1-{{ .Branch }}-{{epoch}}
-            - masks-workdir-v1-{{ .Branch }}-
-            - masks-workdir-v1-master-
-            - masks-workdir-v1-
+            - masks-workdir-v2-{{ .Branch }}-{{epoch}}
+            - masks-workdir-v2-{{ .Branch }}-
+            - masks-workdir-v2-master-
+            - masks-workdir-v2-
       - run:
           name: Run regression tests on EPI masks
           no_output_timeout: 2h
@@ -305,14 +305,29 @@ jobs:
               coverage run -p --rcfile=setup.cfg \
                      -m pytest --junit-xml=/tmp/masks/reports/regression.xml \
                      niworkflows/func/tests/
-      - save_cache:
-         key: masks-workdir-v1-{{ .Branch }}-{{ epoch }}
-         paths:
-            - /tmp/masks/workdir
+      - run:
+          name: Package new masks
+          when: always
+          no_output_timeout: 10m
+          command: |
+            cd reports/
+            tar cvfz /tmp/masks/fmriprep_bold_mask.tar.gz fmriprep_bold_mask/*/*.nii.gz
+      - store_artifacts:
+          path: /tmp/masks/fmriprep_bold_mask.tar.gz
+
+      - run:
+          name: Clear reports folder & delete plot generator cache
+          command: |
+            rm -rf /tmp/masks/reports/fmriprep_bold_mask/
+            find workdir/ -name "mask_diff_plot" -exec rm -rf {} +
       - store_artifacts:
           path: /tmp/masks/reports
       - store_test_results:
           path: /tmp/masks/reports
+      - save_cache:
+         key: masks-workdir-v2-{{ .Branch }}-{{ epoch }}
+         paths:
+            - /tmp/masks/workdir
 
       - run:
           name: Coverage preparation
@@ -337,15 +352,6 @@ jobs:
             cp /tmp/masks/reports/coverage.xml .
             sed -i "s+/src/niworkflows+/tmp/src/niworkflows+g" coverage.xml
             python -m codecov --file coverage.xml --flags masks -e CIRCLE_JOB
-      - run:
-          name: Package new masks
-          when: always
-          no_output_timeout: 10m
-          working_directory: /tmp/data
-          command: |
-            tar cfz /tmp/masks/fmriprep_bold_mask.tar.gz fmriprep_bold_mask/*/*.nii.gz
-      - store_artifacts:
-          path: /tmp/masks/fmriprep_bold_mask.tar.gz
 
   test_package:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,8 +151,8 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - regression-v2-{{ .Revision }}
-            - regression-v2-
+            - regression-v3-{{ .Revision }}
+            - regression-v3-
       - run:
           name: Get truncated BOLD series
           command: |
@@ -175,7 +175,7 @@ jobs:
               echo "Pre-computed masks were cached"
             fi
       - save_cache:
-         key: regression-v2-{{ .Revision }}-{{ epoch }}
+         key: regression-v3-{{ .Revision }}-{{ epoch }}
          paths:
             - /tmp/data
 
@@ -282,7 +282,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - regression-v2-{{ .Revision }}
+            - regression-v3-{{ .Revision }}
       - restore_cache:
           keys:
             - masks-workdir-v2-{{ .Branch }}-{{epoch}}
@@ -306,19 +306,12 @@ jobs:
                      -m pytest --junit-xml=/tmp/masks/reports/regression.xml \
                      niworkflows/func/tests/
       - run:
-          name: Package new masks
-          when: always
-          no_output_timeout: 10m
-          command: |
-            cd reports/
-            tar cvfz /tmp/masks/fmriprep_bold_mask.tar.gz fmriprep_bold_mask/*/*.nii.gz
-      - store_artifacts:
-          path: /tmp/masks/fmriprep_bold_mask.tar.gz
-
-      - run:
           name: Clear reports folder & delete plot generator cache
           command: |
+            pushd reports/
+            tar cvfz fmriprep_bold_mask.tar.gz fmriprep_bold_mask/*/*.nii.gz
             rm -rf /tmp/masks/reports/fmriprep_bold_mask/
+            popd
             find workdir/ -name "mask_diff_plot" -exec rm -rf {} +
       - store_artifacts:
           path: /tmp/masks/reports

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,4 +10,4 @@ sphinx-argparse
 sphinx>=2.1.2,<3.0
 sphinx_rtd_theme
 sphinxcontrib-apidoc ~= 0.3.0
-templateflow >= 0.6.0rc1
+templateflow

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,4 +10,4 @@ sphinx-argparse
 sphinx>=2.1.2,<3.0
 sphinx_rtd_theme
 sphinxcontrib-apidoc ~= 0.3.0
-templateflow
+templateflow >= 0.6.0rc1

--- a/niworkflows/func/tests/test_util.py
+++ b/niworkflows/func/tests/test_util.py
@@ -85,7 +85,7 @@ def test_masking(input_fname, expected_fname):
         bold_reference_wf.base_dir = str(base_dir)
 
     out_fname = fname_presuffix(
-        basename, suffix="_masks.svg", use_ext=False, newpath=str(newpath)
+        basename, suffix="_mask.svg", use_ext=False, newpath=str(newpath)
     )
     newpath.mkdir(parents=True, exist_ok=True)
 

--- a/niworkflows/func/util.py
+++ b/niworkflows/func/util.py
@@ -29,6 +29,7 @@ DEFAULT_MEMORY_MIN_GB = 0.01
 def init_bold_reference_wf(
     omp_nthreads,
     bold_file=None,
+    brainmask_thresh=0.5,
     pre_mask=False,
     name="bold_reference_wf",
     gen_report=False,
@@ -50,10 +51,16 @@ def init_bold_reference_wf(
 
     Parameters
     ----------
-    bold_file : str
-        BOLD series NIfTI file
     omp_nthreads : int
         Maximum number of threads an individual process may use
+    bold_file : str
+        BOLD series NIfTI file
+    brainmask_thresh: :obj:`float`
+        Lower threshold for the probabilistic brainmask to obtain
+        the final binary mask (default: 0.5).
+    pre_mask : bool
+        Indicates whether the ``pre_mask`` input will be set (and thus, step 1
+        should be skipped).
     name : str
         Name of workflow (default: ``bold_reference_wf``)
     gen_report : bool
@@ -133,7 +140,9 @@ using a custom methodology of *fMRIPrep*.
         EstimateReferenceImage(), name="gen_ref", mem_gb=1
     )  # OE: 128x128x128x50 * 64 / 8 ~ 900MB.
     enhance_and_skullstrip_bold_wf = init_enhance_and_skullstrip_bold_wf(
-        omp_nthreads=omp_nthreads, pre_mask=pre_mask
+        brainmask_thresh=brainmask_thresh,
+        omp_nthreads=omp_nthreads,
+        pre_mask=pre_mask,
     )
 
     calc_dummy_scans = pe.Node(
@@ -188,7 +197,10 @@ using a custom methodology of *fMRIPrep*.
 
 
 def init_enhance_and_skullstrip_bold_wf(
-    name="enhance_and_skullstrip_bold_wf", pre_mask=False, omp_nthreads=1
+    brainmask_thresh=0.5,
+    name="enhance_and_skullstrip_bold_wf",
+    omp_nthreads=1,
+    pre_mask=False,
 ):
     """
     Enhance and run brain extraction on a BOLD EPI image.
@@ -238,13 +250,16 @@ def init_enhance_and_skullstrip_bold_wf(
 
     Parameters
     ----------
+    brainmask_thresh: :obj:`float`
+        Lower threshold for the probabilistic brainmask to obtain
+        the final binary mask (default: 0.5).
     name : str
         Name of workflow (default: ``enhance_and_skullstrip_bold_wf``)
+    omp_nthreads : int
+        number of threads available to parallel nodes
     pre_mask : bool
         Indicates whether the ``pre_mask`` input will be set (and thus, step 1
         should be skipped).
-    omp_nthreads : int
-        number of threads available to parallel nodes
 
     Inputs
     ------
@@ -399,7 +414,7 @@ def init_enhance_and_skullstrip_bold_wf(
             ),
             name="map_brainmask",
         )
-        binarize_mask = pe.Node(Binarize(thresh_low=0.15), name="binarize_mask")
+        binarize_mask = pe.Node(Binarize(thresh_low=brainmask_thresh), name="binarize_mask")
 
         # fmt: off
         workflow.connect([

--- a/niworkflows/func/util.py
+++ b/niworkflows/func/util.py
@@ -29,7 +29,7 @@ DEFAULT_MEMORY_MIN_GB = 0.01
 def init_bold_reference_wf(
     omp_nthreads,
     bold_file=None,
-    brainmask_thresh=0.5,
+    brainmask_thresh=0.85,
     pre_mask=False,
     name="bold_reference_wf",
     gen_report=False,
@@ -57,7 +57,7 @@ def init_bold_reference_wf(
         BOLD series NIfTI file
     brainmask_thresh: :obj:`float`
         Lower threshold for the probabilistic brainmask to obtain
-        the final binary mask (default: 0.5).
+        the final binary mask (default: 0.85).
     pre_mask : bool
         Indicates whether the ``pre_mask`` input will be set (and thus, step 1
         should be skipped).

--- a/niworkflows/func/util.py
+++ b/niworkflows/func/util.py
@@ -392,7 +392,7 @@ def init_enhance_and_skullstrip_bold_wf(
                     get_template(
                         "MNI152NLin2009cAsym",
                         resolution=1,
-                        desc="brain",
+                        label="brain",
                         suffix="probseg",
                     )
                 ),

--- a/niworkflows/func/util.py
+++ b/niworkflows/func/util.py
@@ -399,7 +399,7 @@ def init_enhance_and_skullstrip_bold_wf(
             ),
             name="map_brainmask",
         )
-        binarize_mask = pe.Node(Binarize(thresh_low=0.75), name="binarize_mask")
+        binarize_mask = pe.Node(Binarize(thresh_low=0.5), name="binarize_mask")
 
         # fmt: off
         workflow.connect([

--- a/niworkflows/func/util.py
+++ b/niworkflows/func/util.py
@@ -399,7 +399,7 @@ def init_enhance_and_skullstrip_bold_wf(
             ),
             name="map_brainmask",
         )
-        binarize_mask = pe.Node(Binarize(thresh_low=0.5), name="binarize_mask")
+        binarize_mask = pe.Node(Binarize(thresh_low=0.15), name="binarize_mask")
 
         # fmt: off
         workflow.connect([

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     seaborn
     svgutils
     transforms3d
-    templateflow >= 0.4.2
+    templateflow >= 0.5.2
 test_requires =
     coverage < 5
     pytest >= 4.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     seaborn
     svgutils
     transforms3d
-    templateflow >= 0.6.0rc1
+    templateflow >= 0.6
 test_requires =
     coverage < 5
     pytest >= 4.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     seaborn
     svgutils
     transforms3d
-    templateflow >= 0.5.2
+    templateflow >= 0.6.0rc1
 test_requires =
     coverage < 5
     pytest >= 4.4


### PR DESCRIPTION
Replaces the template's binary mask with a probabilistic map.

The workflow for EPI brain-extraction utilizes an atlas-based approach in its initialization. Before this PR, the template's mask is binary. The intention is to minimize numerical instability of edge voxels due to the resampling of the binary mask (i.e., when _moving the atlas' brain mask on to the subject space_). With this PR, the binarization occurs later and the risk of having a voxel whose value varies between runs (due to the minimal but existing variability introduced by the ants registration process) is much lower.

See #476