### PR TITLE
MAINT: Drop Python 3.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,7 +353,7 @@ jobs:
     working_directory: /tmp/src/niworkflows
     steps:
       - checkout
-      - run: pyenv local 3.5.2
+      - run: pyenv local 3.7.0
       - run:
           name: Install build depends
           command: python3 -m pip install "setuptools>=30.4.0" "pip>=10.0.1" "twine<2.0" docutils
@@ -378,7 +378,7 @@ jobs:
     working_directory: /tmp/src/niworkflows
     steps:
       - checkout
-      - run: pyenv local 3.5.2
+      - run: pyenv local 3.7.0
       - run:
           name: Install build depends
           command: python3 -m pip install "setuptools>=30.4.0" "pip>=10.0.1" "twine<2.0" docutils

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ cache:
     - $HOME/.cache/pip
 
 python:
-  - 3.5
   - 3.6
   - 3.7
+  - 3.8
 
 env:
   global:
@@ -30,11 +30,11 @@ matrix:
   - python: 3.7
     env: CHECK_TYPE="style"
   allow_failures:
-  - python: 3.5
-    env: INSTALL_DEPENDS="pip==10.0.1 setuptools==30.4.0"
   - python: 3.6
     env: INSTALL_DEPENDS="pip==10.0.1 setuptools==30.4.0"
   - python: 3.7
+    env: INSTALL_DEPENDS="pip==10.0.1 setuptools==30.4.0"
+  - python: 3.8
     env: INSTALL_DEPENDS="pip==10.0.1 setuptools==30.4.0"
 
 before_install:

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,12 +13,12 @@ classifiers =
     Intended Audience :: Science/Research
     Topic :: Scientific/Engineering :: Image Recognition
     License :: OSI Approved :: BSD License
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >= 3.5
+python_requires = >= 3.6
 install_requires =
     attrs
     jinja2


### PR DESCRIPTION
Addresses #486.

Some mentions to python 3.5 still remain:

```
$ find . -name "*.py" -exec grep -H "35" {} \;
./niworkflows/reports/core.py:        # PY35: Sorted config dict for consistent behavior
./niworkflows/reports/core.py:                # PY35: Coerce to str to pacify os.* functions that don't take Paths until 3.6
./niworkflows/utils/misc.py:    for f in os.scandir(path):  # switch to context manager when py35 dropped
```