### PR TITLE
MAINT: Push docker image to docker hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,7 +372,7 @@ jobs:
             INSTALLED=$( python3 -c 'import niworkflows; print(niworkflows.__version__)' )
             test "${CIRCLE_TAG:-$THISVERSION}" == "$INSTALLED"
 
-  deploy:
+  deploy_pypi:
     machine:
       image: circleci/classic:201808-01
     working_directory: /tmp/src/niworkflows
@@ -401,6 +401,40 @@ jobs:
           name: Upload to PyPi
           command: |
             python3 -m twine upload dist/*
+
+  deploy_docker:
+    machine:
+      image: circleci/classic:201808-01
+    working_directory: /tmp/src/
+    steps:
+      - restore_cache:
+          keys:
+            - build-v1-{{ .Branch }}-{{ epoch }}
+            - build-v1-{{ .Branch }}-
+            - build-v1-master-
+            - build-v1-
+          paths:
+            - /tmp/docker
+      - run:
+          name: Set-up a Docker registry
+          command: |
+            docker run -d -p 5000:5000 --restart=always --name=registry \
+                -v /tmp/docker:/var/lib/registry registry:2
+      - run:
+          name: Pull images from local registry
+          command: |
+            docker pull localhost:5000/niworkflows
+            docker tag localhost:5000/niworkflows nipreps/niworkflows:latest
+      - run:
+          name: Deploy to Docker Hub
+          no_output_timeout: 40m
+          command: |
+            if [[ -n "$DOCKER_PASS" ]]; then
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              docker push nipreps/niworkflows:latest
+              docker tag nipreps/niworkflows nipreps/niworkflows:$CIRCLE_TAG
+              docker push nipreps/niworkflows:$CIRCLE_TAG
+            fi
 
   build_docs:
     docker:
@@ -537,11 +571,20 @@ workflows:
             tags:
               ignore: /.*/
 
-      - deploy:
+      - deploy_pypi:
           requires:
             - test_pytest
             - test_package
             - build_docs
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/
+
+      - deploy_docker:
+          requires:
+            - deploy_pypi
           filters:
             branches:
               ignore: /.*/
@@ -571,7 +614,7 @@ workflows:
 
       - deploy_docs_tag:
           requires:
-            - deploy
+            - deploy_docker
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
Since migrating to the nipreps organization, we haven't been pushing images to dockerhub
https://hub.docker.com/r/nipreps/niworkflows/tags