### PR TITLE
FIX: Stringify select N4-only workflow output fields

### DIFF
--- a/niworkflows/anat/ants.py
+++ b/niworkflows/anat/ants.py
@@ -721,9 +721,9 @@ def init_n4_only_wf(atropos_model=None,
         (inputnode, inu_n4_final, [('in_files', 'input_image')]),
         (inputnode, thr_brainmask, [(('in_files', _pop), 'in_file')]),
         (thr_brainmask, outputnode, [('out_mask', 'out_mask')]),
-        (inu_n4_final, outputnode, [('output_image', 'out_file')]),
-        (inu_n4_final, outputnode, [('output_image', 'bias_corrected')]),
-        (inu_n4_final, outputnode, [('bias_image', 'bias_image')])
+        (inu_n4_final, outputnode, [(('output_image', _pop), 'out_file')]),
+        (inu_n4_final, outputnode, [(('output_image', _pop), 'bias_corrected')]),
+        (inu_n4_final, outputnode, [(('bias_image', _pop), 'bias_image')])
     ])
 
     # If atropos refine, do in4 twice


### PR DESCRIPTION
`init_n4_only_wf` produces outputs of lists, while `init_brain_extraction_wf` reduces lists of 1 elements to strings via CopyXForm:
https://github.com/nipreps/niworkflows/blob/1977707632c5e5f6b424a876e0656c507f39b943/niworkflows/interfaces/utils.py#L79-L81

This changes the `out_file`, `bias_corrected`, and `bias_image` fields of n4 workflow's outputs from lists to strings.

Down the rabbit hole of https://github.com/poldracklab/fmriprep/issues/2061