### PR TITLE
FIX: Merge/SplitSeries write to path of input image, instead of cwd

### DIFF
--- a/niworkflows/interfaces/nibabel.py
+++ b/niworkflows/interfaces/nibabel.py
@@ -1,7 +1,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Nibabel-based interfaces."""
-from pathlib import Path
 import numpy as np
 import nibabel as nb
 from nipype import logging
@@ -124,10 +123,8 @@ class SplitSeries(SimpleInterface):
 
         self._results["out_files"] = []
         for i, img_3d in enumerate(nb.four_to_three(img)):
-            out_file = str(
-                Path(fname_presuffix(in_file, suffix=f"_idx-{i:03}",
-                                     newpath=runtime.cwd)).absolute()
-            )
+            out_file = fname_presuffix(in_file, suffix=f"_idx-{i:03}",
+                                       newpath=runtime.cwd)
             img_3d.to_filename(out_file)
             self._results["out_files"].append(out_file)
 

--- a/niworkflows/interfaces/nibabel.py
+++ b/niworkflows/interfaces/nibabel.py
@@ -125,7 +125,8 @@ class SplitSeries(SimpleInterface):
         self._results["out_files"] = []
         for i, img_3d in enumerate(nb.four_to_three(img)):
             out_file = str(
-                Path(fname_presuffix(in_file, suffix=f"_idx-{i:03}")).absolute()
+                Path(fname_presuffix(in_file, suffix=f"_idx-{i:03}",
+                                     newpath=runtime.cwd)).absolute()
             )
             img_3d.to_filename(out_file)
             self._results["out_files"].append(out_file)
@@ -169,7 +170,8 @@ class MergeSeries(SimpleInterface):
                 )
 
         img_4d = nb.concat_images(nii_list)
-        out_file = fname_presuffix(self.inputs.in_files[0], suffix="_merged")
+        out_file = fname_presuffix(self.inputs.in_files[0], suffix="_merged",
+                                   newpath=runtime.cwd)
         img_4d.to_filename(out_file)
 
         self._results["out_file"] = out_file


### PR DESCRIPTION
Addresses an oversight in #489 .