### PR TITLE
MAINT: Add ``codecov.yml`` config file to reduce noise in PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    project: off


### PR DESCRIPTION
Removes the "project" target from comments in PRs because the segregated
testing of niworkflows (masks, pytests, reportlets, ...) makes almost
all PRs to be under a decent project threshold (and hence show up as
failed).