### PR TITLE
ENH: add ability to set license

### DIFF
--- a/niworkflows/utils/misc.py
+++ b/niworkflows/utils/misc.py
@@ -263,14 +263,31 @@ def pass_dummy_scans(algo_dummy_scans, dummy_scans=None):
     return dummy_scans
 
 
-def check_valid_fs_license():
-    """Run ``mri_convert`` to assess FreeSurfer access to a license."""
+def check_valid_fs_license(lic=None):
+    """
+    Run ``mri_convert`` to assess FreeSurfer access to a license.
+
+    Parameters
+    ----------
+    lic : :obj:`str`, optional
+        Path to FreeSurfer license file
+
+    Returns
+    -------
+    valid : :obj:`bool`
+        FreeSurfer license is valid
+
+    """
     from pathlib import Path
     import subprocess as sp
     from tempfile import TemporaryDirectory
 
     import nibabel as nb
     import numpy as np
+
+    if lic is not None:
+        import os
+        os.environ['FS_LICENSE'] = str(Path(lic).absolute())
 
     with TemporaryDirectory() as tmpdir:
         nii_file = str(Path(tmpdir) / 'test.nii.gz')

--- a/niworkflows/utils/tests/test_misc.py
+++ b/niworkflows/utils/tests/test_misc.py
@@ -1,4 +1,5 @@
 """Test misc module."""
+import os
 from unittest import mock
 
 import pytest
@@ -17,12 +18,15 @@ def test_pass_dummy_scans(algo_dummy_scans, dummy_scans, expected_out):
     assert skip_vols == expected_out
 
 
-@pytest.mark.parametrize('valid,stderr', [
-    (True, b''),
-    (False, b'ERROR: FreeSurfer license file /made/up/license.txt not found'),
-    (True, b'Non-license ERROR'),
+@pytest.mark.parametrize('valid,lic,stderr', [
+    (True, None, b''),
+    (False, None, b'ERROR: FreeSurfer license file /made/up/license.txt not found'),
+    (True, None, b'Non-license ERROR'),
+    (True, 'custom/license.txt', b''),
 ])
-def test_fs_license_check(valid, stderr):
+def test_fs_license_check(valid, lic, stderr):
     with mock.patch('subprocess.run') as mocked_run:
         mocked_run.return_value.stderr = stderr
-        assert check_valid_fs_license() == valid
+        assert check_valid_fs_license(lic=lic) == valid
+        if lic is not None:
+            assert os.getenv('FS_LICENSE')


### PR DESCRIPTION
This adds a missing piece of #505, the ability to set and check non-standard license location (anywhere that isn't `$FREESURFER_HOME/license.txt`)