### PR TITLE
MNT: Update comments, minimum versions for setup requirements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
-recursive-exclude niworkflows/ conftest.py
 include versioneer.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
+recursive-exclude niworkflows/ conftest.py
 include versioneer.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
+# Keep synchronized with the minimum version to install in setup.py
 requires = ["setuptools >= 30.4.0", "wheel"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ classifiers =
     Programming Language :: Python :: 3.8
 description = NeuroImaging Workflows provides processing tools for magnetic resonance images of the brain.
 license = 3-clause BSD
+license_file = LICENSE
 long_description = file:README.rst
 long_description_content_type = text/x-rst; charset=UTF-8
 project_urls =

--- a/setup.py
+++ b/setup.py
@@ -5,15 +5,22 @@ import sys
 from setuptools import setup
 import versioneer
 
-# Give setuptools a hint to complain if it's too old a version
+# Use setup_requires to let setuptools complain if it's too old for a feature we need
 # 30.3.0 allows us to put most metadata in setup.cfg
 # 30.4.0 gives us options.packages.find
-# Should match pyproject.toml
-SETUP_REQUIRES = ['setuptools >= 30.4.0']
+# 40.8.0 includes license_file, reducing MANIFEST.in requirements
+#
+# To install, 30.4.0 is enough, but if we're building an sdist, require 40.8.0
+# This imposes a stricter rule on the maintainer than the user
+# Keep the installation version synchronized with pyproject.toml
+SETUP_REQUIRES = ['setuptools >= %s' % ("40.8.0" if "sdist" in sys.argv else "30.4.0")]
+
 # This enables setuptools to install wheel on-the-fly
 SETUP_REQUIRES += ['wheel'] if 'bdist_wheel' in sys.argv else []
 
 if __name__ == '__main__':
+    # Note that "name" is used by GitHub to determine what repository provides a package
+    # in building its dependency graph.
     setup(name='niworkflows',
           version=versioneer.get_version(),
           cmdclass=versioneer.get_cmdclass(),


### PR DESCRIPTION
Trying to improve the comments to make it clearer why `setup.py`/`setup.cfg` are written the way they are.

In #507, the LICENSE was removed from the sdist, which seems like a mistake to me. This is available with the `license_file` metadata, which setuptools begins to respect in 40.8.0. This only needs to be respected for building sdists, though, so the minimum setuptools to install remains unchanged.

I also think it's a mistake to remove `conftest.py`. Tests are first-class citizens in niworkflows, and should work from an installed copy using `pytest --pyargs niworkflows`. Removing `conftest.py` in sdists will modify the behavior of tests depending on the installation method.