### PR TITLE
MAINT: Revise ``setup.py``/``.cfg``, setuptools pin and PyBIDS pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools >= 30.4.0", "wheel"]
+requires = ["setuptools >= 38.3.0", "wheel"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,34 +13,34 @@ description = NeuroImaging Workflows provides processing tools for magnetic reso
 license = 3-clause BSD
 long_description = file:README.rst
 long_description_content_type = text/x-rst; charset=UTF-8
+name=niworkflows
 project_urls =
+    Home = https://github.com/nipreps/niworkflows
     Documentation = https://www.nipreps.org/niworkflows
-    GitHub = https://github.com/nipreps/niworkflows
     Zenodo = https://doi.org/10.5281/zenodo.2650331
-url = https://github.com/nipreps/niworkflows
 
 [options]
 python_requires = >= 3.6
 install_requires =
     attrs
     jinja2
-    matplotlib >= 2.2.0 ; python_version >= "3.6"
-    matplotlib >= 2.2.0, < 3.1 ; python_version < "3.6"
+    matplotlib ~= 2.2
     nibabel >= 3.0.1
     nilearn >= 0.2.6, != 0.5.0, != 0.5.1
     nipype >= 1.3.1
     packaging
     pandas
-    pybids >= 0.9.4
+    pybids >= 0.10.2
     PyYAML
-    scikit-image == 0.14.4 ; python_version < "3.6"
-    scikit-image ; python_version >= "3.6"
+    scikit-image
     scikit-learn
     scipy
     seaborn
     svgutils
     transforms3d
-    templateflow >= 0.4.2
+    templateflow >= 0.6.0
+setup_requires =
+    setuptools >= 38.3.0
 test_requires =
     coverage < 5
     pytest >= 4.4

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,29 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-""" niworkflows setup script """
+"""NiWorkflows setup script."""
 import sys
 from setuptools import setup
 import versioneer
 
+setupargs = {
+    "version": versioneer.get_version(),
+    "cmdclass": versioneer.get_cmdclass(),
+}
+
 # Give setuptools a hint to complain if it's too old a version
 # 30.3.0 allows us to put most metadata in setup.cfg
 # 30.4.0 gives us options.packages.find
-# Should match pyproject.toml
-SETUP_REQUIRES = ['setuptools >= 30.4.0']
-# This enables setuptools to install wheel on-the-fly
-SETUP_REQUIRES += ['wheel'] if 'bdist_wheel' in sys.argv else []
+# 34.0.2 ensure extras are honored (e.g., for console_scripts)
+# 36.3 Several files within file: directive in metadata.long_description
+# 36.4 Description-Content-Type medatada, misc fixes
+# 36.7 Support setup_requires in setup.cfg files.
+# 38.0 More deterministic builds
+# 38.2.2 fix handling of namespace packages when installing from a wheel.
+# 38.3 Support for long_description_type in setup.cfg, PEP 345 Project-URL metadata
+# Should match pyproject.toml and setup.cfg
 
-if __name__ == '__main__':
-    setup(name='niworkflows',
-          version=versioneer.get_version(),
-          cmdclass=versioneer.get_cmdclass(),
-          setup_requires=SETUP_REQUIRES,
-          )
+if "bdist_wheel" in sys.argv:
+    # This enables setuptools to install wheel on-the-fly
+    setupargs["setup_requires"] = ["setuptools >= 38.3.0", "wheel"]
+
+if __name__ == "__main__":
+    setup(**setupargs)


### PR DESCRIPTION
Following #507 as these changes were out-of-scope there. In this PR:

  * [x] Updated the PyBIDS pin to ``>=0.10.2`` to include the
    ``build_path`` bug-fixes.
  * [x] Updated setuptools to ``>=38.3.0``, because a fair amount of
    metadata had new support in the ``setup.cfg``
  * [x] Added a list of interesting changes in setuptools, included
    as a comment in ``setup.py``.
  * [x] Moved metadata ``name`` to ``setup.cfg``, as it seems something
    have done in ``setuptools`` themselves. Happy to roll back if GitHub
    won't like this, although a quick search did not reveal anything
    relevant.
  * [x] Minimized ``setup.py``, using ``setup_requires`` from
    ``setup.cfg``. The addition of ``wheel`` for ``bdist_wheel`` is
    maintained. If we finally transition from versioneer to
    setuptools-scm, this will leave us with a very minimal ``setup.py``.