### PR TITLE
FIX: Two minor amends to #507

### DIFF
--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -1,12 +1,12 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Interfaces for handling BIDS-like neuroimaging structures."""
-
 from collections import defaultdict
 from json import dumps, loads
 from pathlib import Path
 from shutil import copytree, rmtree
 from pkg_resources import resource_filename as _pkgres
+import re
 
 import nibabel as nb
 import numpy as np
@@ -27,6 +27,7 @@ from ..utils.bids import _init_layout, relative_to_root
 from ..utils.images import overwrite_header
 from ..utils.misc import splitext as _splitext, _copy_any
 
+regz = re.compile(r"\.gz$")
 _pybids_spec = loads(
     Path(_pkgres("niworkflows", "data/nipreps.json")).read_text()
 )
@@ -465,7 +466,7 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
             compress = compress * len(in_file)
         for i, ext in enumerate(out_entities["extension"]):
             if compress[i] is not None:
-                ext = ext.rstrip(".gz")
+                ext = regz.sub("", ext)
                 out_entities["extension"][i] = f"{ext}.gz" if compress[i] else ext
 
         # Override entities with those set as inputs

--- a/niworkflows/utils/misc.py
+++ b/niworkflows/utils/misc.py
@@ -1,8 +1,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-"""
-Miscellaneous utilities
-"""
+"""Miscellaneous utilities."""
 import os
 import shutil
 
@@ -168,8 +166,11 @@ def _read_txt(path):
 
 
 def splitext(fname):
-    """Splits filename and extension (.gz safe)
+    """
+    Split filename in name and extension (.gz safe).
 
+    Examples
+    --------
     >>> splitext('some/file.nii.gz')
     ('file', '.nii.gz')
     >>> splitext('some/other/file.nii')
@@ -178,6 +179,12 @@ def splitext(fname):
     ('otherext', '.tar.gz')
     >>> splitext('text.txt')
     ('text', '.txt')
+    >>> splitext('some/figure.svg')
+    ('figure', '.svg')
+    >>> splitext('some/figure.svg.gz')
+    ('figure', '.svg.gz')
+    >>> splitext('some/sub-01_bold.func.gii')
+    ('sub-01_bold.func', '.gii')
 
     """
     from pathlib import Path

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     nipype >= 1.3.1
     packaging
     pandas
-    pybids >= 0.9.4
+    pybids >= 0.10.2
     PyYAML
     scikit-image == 0.14.4 ; python_version < "3.6"
     scikit-image ; python_version >= "3.6"


### PR DESCRIPTION
Quickfix for two problems:

- [x] Pin PyBIDS >=0.10.2 which includes bugfixes to ``build_path`` (this did not jump out in pinned smriprep, fmriprep, etc. because those projects are already pinned that way, and because we might not have reproduced the bugs).
- [x] Improved stripping of ``.gz`` extensions. We were using ``rstrip`` with the following caveat:

  ```Python
  >>> "some.file.svg".rstrip(".gz")
  'some.file.sv'
  ```

  This PR uses a regexp to ensure this is not occurring. Also, it ~~fixes ``niworkflows.utils.misc.splitext`` for the same issue.~~ just adds a couple of doctests to better cover that function.