### PR TITLE
MAINT: Remove conditional dependencies on Python <3.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,7 @@ python_requires = >= 3.6
 install_requires =
     attrs
     jinja2
-    matplotlib >= 2.2.0 ; python_version >= "3.6"
-    matplotlib >= 2.2.0, < 3.1 ; python_version < "3.6"
+    matplotlib >= 2.2.0
     nibabel >= 3.0.1
     nilearn >= 0.2.6, != 0.5.0, != 0.5.1
     nipype >= 1.3.1
@@ -33,8 +32,7 @@ install_requires =
     pandas
     pybids >= 0.10.2
     PyYAML
-    scikit-image == 0.14.4 ; python_version < "3.6"
-    scikit-image ; python_version >= "3.6"
+    scikit-image < 0.17
     scikit-learn
     scipy
     seaborn

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     pandas
     pybids >= 0.10.2
     PyYAML
-    scikit-image < 0.17
+    scikit-image
     scikit-learn
     scipy
     seaborn


### PR DESCRIPTION
~A new release of skimage is breaking or tests. Also,~ 

Remove leftovers of dependencies pinned for Python < 3.6 (#486)