### PR TITLE
CI: Fix skimage 0.17-induced failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,7 +356,7 @@ jobs:
       - run: pyenv local 3.7.0
       - run:
           name: Install build depends
-          command: python3 -m pip install "setuptools>=30.4.0" "pip>=10.0.1" "twine<2.0" docutils
+          command: python3 -m pip install "setuptools>=40.8.0" "pip>=19" "twine<2.0" docutils
       - run:
           name: Build and check
           command: |
@@ -381,7 +381,7 @@ jobs:
       - run: pyenv local 3.7.0
       - run:
           name: Install build depends
-          command: python3 -m pip install "setuptools>=30.4.0" "pip>=10.0.1" "twine<2.0" docutils
+          command: python3 -m pip install "setuptools>=40.8.0" "pip>=19" "twine<2.0" docutils
       - run:
           name: Build and check
           command: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,6 @@ before_script:
             tar xvzf - -C $HOME/.cache/stanford-crn
         curl -sSL "https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/57f328f6b83f6901ef94cf70" |
             tar xvzf - -C $HOME/.cache/stanford-crn
-        python -c "import skimage"      # XXX: temporary hack; remove when Pooch 1.1.1 or higher is released
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # vim ft=yaml
+os: linux
 dist: xenial
-sudo: true
 language: python
 
 cache:
@@ -17,25 +17,17 @@ env:
     - CHECK_TYPE="install"
     - INSTALL_TYPE="pip"
     - INSTALL_DEPENDS="pip setuptools"
-  matrix:
+  jobs:
     - CHECK_TYPE="style"
     - CHECK_TYPE="test"
     - INSTALL_TYPE="sdist"
     - INSTALL_TYPE="wheel"
-    - INSTALL_DEPENDS="pip==18.1 setuptools==30.2.1"
-    - INSTALL_DEPENDS="pip==10.0.1 setuptools==30.4.0"
+    - INSTALL_DEPENDS="pip==19.0 setuptools==30.2.1"
 
-matrix:
+jobs:
   exclude:
   - python: 3.7
     env: CHECK_TYPE="style"
-  allow_failures:
-  - python: 3.6
-    env: INSTALL_DEPENDS="pip==10.0.1 setuptools==30.4.0"
-  - python: 3.7
-    env: INSTALL_DEPENDS="pip==10.0.1 setuptools==30.4.0"
-  - python: 3.8
-    env: INSTALL_DEPENDS="pip==10.0.1 setuptools==30.4.0"
 
 before_install:
   - python -m pip install --upgrade pip virtualenv
@@ -78,6 +70,7 @@ before_script:
             tar xvzf - -C $HOME/.cache/stanford-crn
         curl -sSL "https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/57f328f6b83f6901ef94cf70" |
             tar xvzf - -C $HOME/.cache/stanford-crn
+        python -c "import skimage"      # XXX: temporary hack; remove when Pooch 1.1.1 or higher is released
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
   - python -m pip --version
   - |
     if [ "$INSTALL_TYPE" == "pip" ]; then
-        PACKAGE="-e ."
+        PACKAGE="."
     elif [ "$INSTALL_TYPE" == "sdist" ]; then
         python setup.py sdist
         PACKAGE="$( ls dist/*.tar.gz )"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     - CHECK_TYPE="test"
     - INSTALL_TYPE="sdist"
     - INSTALL_TYPE="wheel"
-    - INSTALL_DEPENDS="pip==19.0 setuptools==30.2.1"
+    - INSTALL_DEPENDS="pip==19.0 setuptools==40.8.0"
 
 jobs:
   exclude:


### PR DESCRIPTION
imagecodecs has kind of forced our hand with regard to testing lower version pip/setuptools. To handle manylinux2010, we need pip 19+.

Also cleaned up the `.travis.yml` based on config validation, adding an `os` entry, dropping the deprecated `sudo`, and renaming `matrix` to `jobs`.