### PR TITLE
FIX: Non-integer data coercion initialization

### DIFF
--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -605,7 +605,7 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
                         if np.issubdtype(data_dtype, np.integer):
                             new_data = np.rint(nii.dataobj).astype(data_dtype)
                         else:
-                            new_data = data_dtype(nii.dataobj)
+                            new_data = np.asanyarray(nii.dataobj, dtype=data_dtype)
                         # and set header to match
                         nii.set_data_dtype(data_dtype)
                         nii = nii.__class__(new_data, nii.affine, nii.header)

--- a/niworkflows/interfaces/tests/test_bids.py
+++ b/niworkflows/interfaces/tests/test_bids.py
@@ -276,7 +276,7 @@ def test_DerivativesDataSink_build_path(
     "space, size, units, xcodes, zipped, fixed, data_dtype",
     [
         ("T1w", (30, 30, 30, 10), ("mm", "sec"), (2, 2), True, [False], None),
-        ("T1w", (30, 30, 30, 10), ("mm", "sec"), (0, 2), True, [True], None),
+        ("T1w", (30, 30, 30, 10), ("mm", "sec"), (0, 2), True, [True], "float64"),
         ("T1w", (30, 30, 30, 10), ("mm", "sec"), (0, 0), True, [True], "<i4"),
         ("T1w", (30, 30, 30, 10), ("mm", None), (2, 2), True, [True], "<f4"),
         ("T1w", (30, 30, 30, 10), (None, None), (0, 2), True, [True], None),


### PR DESCRIPTION
Supplements #527; Non-integer data initialization wasn't being exercised by the tests, and was leading to:
```
TypeError: 'numpy.dtype' object is not callable
```