### PR TITLE
Conform fix zooms

### DIFF
--- a/niworkflows/interfaces/images.py
+++ b/niworkflows/interfaces/images.py
@@ -304,8 +304,8 @@ class Conform(SimpleInterface):
             # Common assumption; if we're wrong, unlikely to be the only thing that breaks
             xyz_unit = "mm"
 
-        # Set a 0.01mm threshold to performing rescaling
-        atol = {"meter": 1e-5, "mm": 0.01, "micron": 10}[xyz_unit]
+        # Set a 0.05mm threshold to performing rescaling
+        atol = {"meter": 5e-5, "mm": 0.05, "micron": 50}[xyz_unit]
         # if 0.01 > difference > 0.001mm, freesurfer won't be able to merge the images
         atol_fine = {"meter": 1e-6, "mm": 0.001, "micron": 1}[xyz_unit]
 

--- a/niworkflows/interfaces/images.py
+++ b/niworkflows/interfaces/images.py
@@ -305,37 +305,37 @@ class Conform(SimpleInterface):
             xyz_unit = "mm"
 
         # Set a 0.05mm threshold to performing rescaling
-        atol = {"meter": 5e-5, "mm": 0.05, "micron": 50}[xyz_unit]
+        atol_gross = {"meter": 5e-5, "mm": 0.05, "micron": 50}[xyz_unit]
         # if 0.01 > difference > 0.001mm, freesurfer won't be able to merge the images
         atol_fine = {"meter": 1e-6, "mm": 0.001, "micron": 1}[xyz_unit]
 
-        # Rescale => change zooms
-        # Fix zooms => set zooms without changing affine
-        # Resize => update image dimensions
-        rescale = not np.allclose(zooms, target_zooms, atol=atol)
-        fix_zooms = not np.allclose(zooms, target_zooms, atol=atol_fine)
+        # Update zooms => Modify affine
+        # Rescale => Resample to resized voxels
+        # Resize => Resample to new image dimensions
+        update_zooms = not np.allclose(zooms, target_zooms, atol=atol_fine, rtol=0)
+        rescale = not np.allclose(zooms, target_zooms, atol=atol_gross, rtol=0)
         resize = not np.all(shape == target_shape)
-        if rescale or resize or fix_zooms:
-            if rescale:
+        resample = rescale or resize
+        if resample or update_zooms:
+            # Use an affine with the corrected zooms, whether or not we resample
+            if update_zooms:
                 scale_factor = target_zooms / zooms
-                target_affine[:3, :3] = reoriented.affine[:3, :3].dot(
-                    np.diag(scale_factor)
-                )
-            elif fix_zooms:
-                reoriented.header.set_zooms(target_zooms)
+                target_affine[:3, :3] = reoriented.affine[:3, :3] @ np.diag(scale_factor)
 
             if resize:
                 # The shift is applied after scaling.
                 # Use a proportional shift to maintain relative position in dataset
                 size_factor = target_span / (zooms * shape)
                 # Use integer shifts to avoid unnecessary interpolation
-                offset = (
-                    reoriented.affine[:3, 3] * size_factor - reoriented.affine[:3, 3]
-                )
+                offset = reoriented.affine[:3, 3] * size_factor - reoriented.affine[:3, 3]
                 target_affine[:3, 3] = reoriented.affine[:3, 3] + offset.astype(int)
 
-            data = nli.resample_img(reoriented, target_affine, target_shape).dataobj
-            conform_xfm = np.linalg.inv(reoriented.affine).dot(target_affine)
+            conform_xfm = np.linalg.inv(reoriented.affine) @ target_affine
+
+            # Create new image
+            data = reoriented.dataobj
+            if resample:
+                data = nli.resample_img(reoriented, target_affine, target_shape).dataobj
             reoriented = reoriented.__class__(data, target_affine, reoriented.header)
 
         # Image may be reoriented, rescaled, and/or resized

--- a/niworkflows/interfaces/images.py
+++ b/niworkflows/interfaces/images.py
@@ -304,7 +304,7 @@ class Conform(SimpleInterface):
             # Common assumption; if we're wrong, unlikely to be the only thing that breaks
             xyz_unit = "mm"
 
-        # Set a 0.05mm threshold to performing rescaling
+        # Set a 0.01mm threshold to performing rescaling
         atol = {"meter": 1e-5, "mm": 0.01, "micron": 10}[xyz_unit]
 
         # Rescale => change zooms


### PR DESCRIPTION
closes [smriprep/issues/198](https://github.com/poldracklab/smriprep/issues/198).
Conform resizes voxels if the difference between zooms is at least 0.01mm. Freesurfer's tolerance is [0.001 mm](https://github.com/freesurfer/freesurfer/blob/4db941ef298c0ac5fb78c29fd0e95571ac363e16/mri_robust_register/MultiRegistration.cpp#L258), which throws `mri_robust_template` off if 0.01>difference>0.001.
This PR fixes the zooms in that case.
 
I have added tests, but haven't tried it with real data in smriprep. @effigies, @oesteban, could you please take a look whether this makes sense, then I'll also run smriprep with real data.