### PR TITLE
FIX: Restore and deprecate license argument to check_valid_fs_license

### DIFF
--- a/niworkflows/utils/misc.py
+++ b/niworkflows/utils/misc.py
@@ -307,6 +307,10 @@ def check_valid_fs_license(lic=None):
 
     env = os.environ.copy()
     if lic is not None:
+        import warnings
+        warnings.warn("The license argument has been deprecated. Please set the environment "
+                      "if needed before calling this function without arguments.",
+                      DeprecationWarning)
         env["FS_LICENSE"] = os.path.abspath(lic)
 
     with TemporaryDirectory() as tmpdir:

--- a/niworkflows/utils/misc.py
+++ b/niworkflows/utils/misc.py
@@ -289,7 +289,7 @@ def pass_dummy_scans(algo_dummy_scans, dummy_scans=None):
     return dummy_scans
 
 
-def check_valid_fs_license():
+def check_valid_fs_license(lic=None):
     """
     Run ``mri_convert`` to assess FreeSurfer access to a license.
 
@@ -299,10 +299,15 @@ def check_valid_fs_license():
         FreeSurfer successfully executed (valid license)
 
     """
+    import os
     from pathlib import Path
     import subprocess as sp
     from tempfile import TemporaryDirectory
     from pkg_resources import resource_filename
+
+    env = os.environ.copy()
+    if lic is not None:
+        env["FS_LICENSE"] = os.path.abspath(lic)
 
     with TemporaryDirectory() as tmpdir:
         # quick FreeSurfer command
@@ -311,7 +316,7 @@ def check_valid_fs_license():
             resource_filename("niworkflows", "data/sentinel.nii.gz"),
             str(Path(tmpdir) / "out.mgz"),
         )
-        proc = sp.run(_cmd, stdout=sp.PIPE, stderr=sp.STDOUT)
+        proc = sp.run(_cmd, stdout=sp.PIPE, stderr=sp.STDOUT, env=env)
     return proc.returncode == 0 and "ERROR:" not in proc.stdout.decode()
 
 

--- a/niworkflows/utils/misc.py
+++ b/niworkflows/utils/misc.py
@@ -308,7 +308,7 @@ def check_valid_fs_license(lic=None):
     env = os.environ.copy()
     if lic is not None:
         import warnings
-        warnings.warn("The license argument has been deprecated. Please set the environment "
+        warnings.warn("The license argument has been deprecated and will be removed in 1.3.0. Please set the environment "
                       "if needed before calling this function without arguments.",
                       DeprecationWarning)
         env["FS_LICENSE"] = os.path.abspath(lic)

--- a/niworkflows/utils/misc.py
+++ b/niworkflows/utils/misc.py
@@ -299,20 +299,17 @@ def check_valid_fs_license(lic=None):
         FreeSurfer successfully executed (valid license)
 
     """
-    import os
     from pathlib import Path
     import subprocess as sp
     from tempfile import TemporaryDirectory
     from pkg_resources import resource_filename
 
-    env = os.environ.copy()
     if lic is not None:
         import warnings
-        warnings.warn("The license argument has been deprecated and will be removed in 1.3.0. "
-                      "Please set the environment if needed before calling this function "
-                      "without arguments.",
+        warnings.warn("The license argument has been deprecated, has no effect, and will be "
+                      "removed in 1.3.0. Please set the environment if needed before calling "
+                      "this function without arguments.",
                       DeprecationWarning)
-        env["FS_LICENSE"] = os.path.abspath(lic)
 
     with TemporaryDirectory() as tmpdir:
         # quick FreeSurfer command
@@ -321,7 +318,7 @@ def check_valid_fs_license(lic=None):
             resource_filename("niworkflows", "data/sentinel.nii.gz"),
             str(Path(tmpdir) / "out.mgz"),
         )
-        proc = sp.run(_cmd, stdout=sp.PIPE, stderr=sp.STDOUT, env=env)
+        proc = sp.run(_cmd, stdout=sp.PIPE, stderr=sp.STDOUT)
     return proc.returncode == 0 and "ERROR:" not in proc.stdout.decode()
 
 

--- a/niworkflows/utils/misc.py
+++ b/niworkflows/utils/misc.py
@@ -308,8 +308,9 @@ def check_valid_fs_license(lic=None):
     env = os.environ.copy()
     if lic is not None:
         import warnings
-        warnings.warn("The license argument has been deprecated and will be removed in 1.3.0. Please set the environment "
-                      "if needed before calling this function without arguments.",
+        warnings.warn("The license argument has been deprecated and will be removed in 1.3.0. "
+                      "Please set the environment if needed before calling this function "
+                      "without arguments.",
                       DeprecationWarning)
         env["FS_LICENSE"] = os.path.abspath(lic)
 

--- a/niworkflows/utils/tests/test_misc.py
+++ b/niworkflows/utils/tests/test_misc.py
@@ -34,7 +34,8 @@ def test_fs_license_check(stdout, rc, valid):
         assert check_valid_fs_license() is valid
 
 
-@pytest.mark.skipif(not os.getenv("FS_LICENSE"), reason="No FS license found")
+@pytest.mark.skipif(shutil.which('mri_convert') is None, reason="FreeSurfer not installed")
+@pytest.mark.xfail(not os.getenv("FS_LICENSE"), reason="No FS license found")
 def test_fs_license_check2():
     """Execute the canary itself."""
     assert check_valid_fs_license() is True

--- a/niworkflows/utils/tests/test_misc.py
+++ b/niworkflows/utils/tests/test_misc.py
@@ -47,3 +47,12 @@ def test_fs_license_check3(monkeypatch):
         m.delenv("FS_LICENSE", raising=False)
         m.delenv("FREESURFER_HOME", raising=False)
         assert check_valid_fs_license() is False
+
+
+@pytest.mark.skipif(not os.getenv("FS_LICENSE"), reason="No FS license found")
+def test_fs_license_check4(monkeypatch):
+    """Execute the canary with passed license."""
+    lic = os.getenv("FS_LICENSE")
+    with monkeypatch.context() as m:
+        m.delenv("FS_LICENSE")
+        assert check_valid_fs_license(lic=lic) is True

--- a/niworkflows/utils/tests/test_misc.py
+++ b/niworkflows/utils/tests/test_misc.py
@@ -18,21 +18,20 @@ def test_pass_dummy_scans(algo_dummy_scans, dummy_scans, expected_out):
 
 
 @pytest.mark.parametrize(
-    "stdout,lic,rc,valid",
+    "stdout,rc,valid",
     [
-        (b"Successful command", None, 0, True),
-        (b"Successful command", "custom/license.txt", 0, True),
-        (b"", None, 0, True),
-        (b"ERROR: FreeSurfer license file /made/up/license.txt not found", None, 1, False),
-        (b"Failed output", None, 1, False),
-        (b"ERROR: Systems running GNU glibc version greater than 2.15", None, 0, False),
+        (b"Successful command", 0, True),
+        (b"", 0, True),
+        (b"ERROR: FreeSurfer license file /made/up/license.txt not found", 1, False),
+        (b"Failed output", 1, False),
+        (b"ERROR: Systems running GNU glibc version greater than 2.15", 0, False),
     ],
 )
-def test_fs_license_check(stdout, lic, rc, valid):
+def test_fs_license_check(stdout, rc, valid):
     with mock.patch("subprocess.run") as mocked_run:
         mocked_run.return_value.stdout = stdout
         mocked_run.return_value.returncode = rc
-        assert check_valid_fs_license(lic=lic) is valid
+        assert check_valid_fs_license() is valid
 
 
 @pytest.mark.skipif(not os.getenv("FS_LICENSE"), reason="No FS license found")
@@ -55,4 +54,5 @@ def test_fs_license_check4(monkeypatch):
     lic = os.getenv("FS_LICENSE")
     with monkeypatch.context() as m:
         m.delenv("FS_LICENSE")
-        assert check_valid_fs_license(lic=lic) is True
+        with pytest.deprecated_call():
+            assert check_valid_fs_license(lic=lic) is True

--- a/niworkflows/utils/tests/test_misc.py
+++ b/niworkflows/utils/tests/test_misc.py
@@ -48,11 +48,10 @@ def test_fs_license_check3(monkeypatch):
         assert check_valid_fs_license() is False
 
 
-@pytest.mark.skipif(not os.getenv("FS_LICENSE"), reason="No FS license found")
-def test_fs_license_check4(monkeypatch):
+def test_fs_license_check_deprecated_arg():
     """Execute the canary with passed license."""
-    lic = os.getenv("FS_LICENSE")
-    with monkeypatch.context() as m:
-        m.delenv("FS_LICENSE")
+    with mock.patch("subprocess.run") as mocked_run:
+        mocked_run.return_value.stdout = b""
+        mocked_run.return_value.returncode = 0
         with pytest.deprecated_call():
-            assert check_valid_fs_license(lic=lic) is True
+            check_valid_fs_license(lic="Any non-None value")

--- a/niworkflows/utils/tests/test_misc.py
+++ b/niworkflows/utils/tests/test_misc.py
@@ -18,24 +18,25 @@ def test_pass_dummy_scans(algo_dummy_scans, dummy_scans, expected_out):
 
 
 @pytest.mark.parametrize(
-    "stdout,rc,valid",
+    "stdout,lic,rc,valid",
     [
-        (b"Successful command", 0, True),
-        (b"", 0, True),
-        (b"ERROR: FreeSurfer license file /made/up/license.txt not found", 1, False),
-        (b"Failed output", 1, False),
-        (b"ERROR: Systems running GNU glibc version greater than 2.15", 0, False),
+        (b"Successful command", None, 0, True),
+        (b"Successful command", "custom/license.txt", 0, True),
+        (b"", None, 0, True),
+        (b"ERROR: FreeSurfer license file /made/up/license.txt not found", None, 1, False),
+        (b"Failed output", None, 1, False),
+        (b"ERROR: Systems running GNU glibc version greater than 2.15", None, 0, False),
     ],
 )
-def test_fs_license_check(stdout, rc, valid):
+def test_fs_license_check(stdout, lic, rc, valid):
     with mock.patch("subprocess.run") as mocked_run:
         mocked_run.return_value.stdout = stdout
         mocked_run.return_value.returncode = rc
-        assert check_valid_fs_license() is valid
+        assert check_valid_fs_license(lic=lic) is valid
 
 
 @pytest.mark.skipif(not os.getenv("FS_LICENSE"), reason="No FS license found")
-def test_fs_license_check2(monkeypatch):
+def test_fs_license_check2():
     """Execute the canary itself."""
     assert check_valid_fs_license() is True
 


### PR DESCRIPTION
#533 broke API mid-series. This restores it while also not modifying the environment.

Target: 1.2.6.