### PR TITLE
fix: skip t1w file existence check if anat_derivatives are provided

### DIFF
--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -222,7 +222,7 @@ class BIDSDataGrabber(SimpleInterface):
 
     def __init__(self, *args, **kwargs):
         anat_only = kwargs.pop("anat_only")
-        anat_derivatives = kwargs.pop("anat_derivatives")
+        anat_derivatives = kwargs.pop("anat_derivatives", None)
         super(BIDSDataGrabber, self).__init__(*args, **kwargs)
         if anat_only is not None:
             self._require_funcs = not anat_only

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -226,8 +226,7 @@ class BIDSDataGrabber(SimpleInterface):
         super(BIDSDataGrabber, self).__init__(*args, **kwargs)
         if anat_only is not None:
             self._require_funcs = not anat_only
-        if anat_derivatives is not None:
-            self._require_t1w = not anat_derivatives
+        self._require_t1w = anat_derivatives is None
 
     def _run_interface(self, runtime):
         bids_dict = self.inputs.subject_data

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -222,9 +222,12 @@ class BIDSDataGrabber(SimpleInterface):
 
     def __init__(self, *args, **kwargs):
         anat_only = kwargs.pop("anat_only")
+        anat_derivatives = kwargs.pop("anat_derivatives")
         super(BIDSDataGrabber, self).__init__(*args, **kwargs)
         if anat_only is not None:
             self._require_funcs = not anat_only
+        if anat_derivatives is not None:
+            self._require_t1w = not anat_derivatives
 
     def _run_interface(self, runtime):
         bids_dict = self.inputs.subject_data
@@ -232,7 +235,7 @@ class BIDSDataGrabber(SimpleInterface):
         self._results["out_dict"] = bids_dict
         self._results.update(bids_dict)
 
-        if not bids_dict["t1w"]:
+        if self._require_t1w and not bids_dict['t1w']:
             raise FileNotFoundError(
                 "No T1w images found for subject sub-{}".format(self.inputs.subject_id)
             )


### PR DESCRIPTION
Changes to allow processing dataset without T1w series if `--anat_derivatives` are provided.
See https://github.com/poldracklab/fmriprep/pull/2201 