### PR TITLE
ENH: Add ``smooth`` input to ``RegridToZooms``

### DIFF
--- a/niworkflows/interfaces/images.py
+++ b/niworkflows/interfaces/images.py
@@ -42,6 +42,13 @@ class _RegridToZoomsInputSpec(BaseInterfaceInputSpec):
         usedefault=True,
         desc="clip the data array within the original image's range",
     )
+    smooth = traits.Either(
+        False,
+        traits.Bool(),
+        traits.Float(),
+        usedefault=True,
+        desc="apply gaussian smoothing before resampling"
+    )
 
 
 class _RegridToZoomsOutputSpec(TraitedSpec):
@@ -65,6 +72,7 @@ class RegridToZooms(SimpleInterface):
             self.inputs.zooms,
             order=self.inputs.order,
             clip=self.inputs.clip,
+            smooth=self.inputs.smooth,
         ).to_filename(self._results["out_file"])
         return runtime
 

--- a/niworkflows/interfaces/images.py
+++ b/niworkflows/interfaces/images.py
@@ -43,9 +43,9 @@ class _RegridToZoomsInputSpec(BaseInterfaceInputSpec):
         desc="clip the data array within the original image's range",
     )
     smooth = traits.Either(
-        False,
         traits.Bool(),
         traits.Float(),
+        default=False,
         usedefault=True,
         desc="apply gaussian smoothing before resampling"
     )

--- a/niworkflows/utils/images.py
+++ b/niworkflows/utils/images.py
@@ -163,7 +163,6 @@ def resample_by_spacing(in_file, zooms, order=3, clip=True, smooth=False):
     qform, qcode = in_file.get_qform(coded=True)
 
     hdr = in_file.header.copy()
-    dtype = hdr.get_data_dtype()
     zooms = np.array(zooms)
 
     # Calculate the factors to normalize voxel size to the specific zooms
@@ -195,22 +194,18 @@ def resample_by_spacing(in_file, zooms, order=3, clip=True, smooth=False):
     )
 
     if smooth:
-        from numbers import Integral
         from scipy.ndimage import gaussian_filter
         if smooth is True:
             smooth = np.maximum(0, (pre_zooms / zooms - 1) / 2)
         data = gaussian_filter(in_file.get_fdata(), smooth)
-        if issubclass(dtype, Integral):
-            data = np.round(data)
-        data = data.astype(dtype)
     else:
-        data = np.asarray(in_file.dataobj, dtype=dtype)
+        data = np.asarray(in_file.dataobj)
 
     # Resample data in the new grid
     resampled = map_coordinates(
         data,
         ijk[:3, :],
-        output=dtype,
+        output=hdr.get_data_dtype(),
         order=order,
         mode="constant",
         cval=0,

--- a/niworkflows/utils/images.py
+++ b/niworkflows/utils/images.py
@@ -205,7 +205,6 @@ def resample_by_spacing(in_file, zooms, order=3, clip=True, smooth=False):
     resampled = map_coordinates(
         data,
         ijk[:3, :],
-        output=hdr.get_data_dtype(),
         order=order,
         mode="constant",
         cval=0,

--- a/niworkflows/utils/images.py
+++ b/niworkflows/utils/images.py
@@ -195,11 +195,16 @@ def resample_by_spacing(in_file, zooms, order=3, clip=True, smooth=False):
     )
 
     if smooth:
+        from numbers import Integral
         from scipy.ndimage import gaussian_filter
-        data = gaussian_filter(in_file.get_fdata(),
-                               2 if smooth is True else smooth).astype(dtype)
+        if smooth is True:
+            smooth = np.maximum(0, (pre_zooms / zooms - 1) / 2)
+        data = gaussian_filter(in_file.get_fdata(), smooth)
+        if issubclass(dtype, Integral):
+            data = np.round(data)
+        data = data.astype(dtype)
     else:
-        data = np.asanyarray(in_file.dataobj)
+        data = np.asarray(in_file.dataobj, dtype=dtype)
 
     # Resample data in the new grid
     resampled = map_coordinates(


### PR DESCRIPTION
Resampling (up- or down-) typically requires a gussian smoothing to be
run before, so that outliers are not introduced (esp. when
downsampling).

This PR adds this option, relying on scipy.

This is the first element of a series of PRs deconstructing #506 into digestible, independent bits.