### PR TITLE
FIX: Pin PyBIDS < 0.11 (and TemplateFlow < 0.6.3) only on the 1.2.x series.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     nitransforms >= 20.0.0rc3,<20.2
     packaging
     pandas
-    pybids >= 0.10.2
+    pybids ~= 0.10.2
     PyYAML
     scikit-image
     scikit-learn
@@ -40,7 +40,7 @@ install_requires =
     seaborn
     svgutils
     transforms3d
-    templateflow >= 0.4.2
+    templateflow >= 0.4.2, < 0.6.3
 test_requires =
     coverage < 5
     pytest >= 4.4


### PR DESCRIPTION
See #548 for the fix in the development branch.