### PR TITLE
FIX: Patch ApplyTransforms spec to permit identity in a chain

### DIFF
--- a/niworkflows/interfaces/fixes.py
+++ b/niworkflows/interfaces/fixes.py
@@ -4,9 +4,9 @@ import os
 
 import nibabel as nb
 
-from nipype.interfaces.base import traits
+from nipype.interfaces.base import traits, InputMultiObject, File
 from nipype.utils.filemanip import fname_presuffix
-from nipype.interfaces.ants.resampling import ApplyTransforms
+from nipype.interfaces.ants.resampling import ApplyTransforms, ApplyTransformsInputSpec
 from nipype.interfaces.ants.registration import Registration
 from nipype.interfaces.ants.segmentation import (
     N4BiasFieldCorrection as VanillaN4,
@@ -17,12 +17,22 @@ from .. import __version__
 from .utils import _copyxform
 
 
+class FixTraitApplyTransformsInputSpec(ApplyTransformsInputSpec):
+    transforms = InputMultiObject(
+        traits.Either(File(exists=True), 'identity'),
+        argstr="%s",
+        mandatory=True,
+        desc="transform files: will be applied in reverse order. For "
+        "example, the last specified transform will be applied first.",
+    )
+
 class FixHeaderApplyTransforms(ApplyTransforms):
     """
     A replacement for nipype.interfaces.ants.resampling.ApplyTransforms that
     fixes the resampled image header to match the xform of the reference
     image
     """
+    input_spec = FixTraitApplyTransformsInputSpec
 
     def _run_interface(self, runtime, correct_return_codes=(0,)):
         # Run normally

--- a/niworkflows/interfaces/itk.py
+++ b/niworkflows/interfaces/itk.py
@@ -254,6 +254,10 @@ def _arrange_xfms(transforms, num_files, tmp_folder):
     # Initialize the transforms matrix
     xfms_T = []
     for i, tf_file in enumerate(transforms):
+        if tf_file == "identity":
+            xfms_T.append([tf_file] * num_files)
+            continue
+
         # If it is a deformation field, copy to the tfs_matrix directly
         if guess_type(tf_file)[0] != "text/plain":
             xfms_T.append([tf_file] * num_files)

--- a/niworkflows/interfaces/itk.py
+++ b/niworkflows/interfaces/itk.py
@@ -12,17 +12,17 @@ from nipype.interfaces.base import (
     TraitedSpec,
     BaseInterfaceInputSpec,
     File,
-    InputMultiPath,
-    OutputMultiPath,
+    InputMultiObject,
+    OutputMultiObject,
     SimpleInterface,
 )
-from nipype.interfaces.ants.resampling import ApplyTransformsInputSpec
+from niworkflows.interfaces.fixes import FixTraitApplyTransformsInputSpec
 
 LOGGER = logging.getLogger("nipype.interface")
 
 
 class _MCFLIRT2ITKInputSpec(BaseInterfaceInputSpec):
-    in_files = InputMultiPath(
+    in_files = InputMultiObject(
         File(exists=True), mandatory=True, desc="list of MAT files from MCFLIRT"
     )
     in_reference = File(
@@ -96,8 +96,8 @@ class MCFLIRT2ITK(SimpleInterface):
         return runtime
 
 
-class _MultiApplyTransformsInputSpec(ApplyTransformsInputSpec):
-    input_image = InputMultiPath(
+class _MultiApplyTransformsInputSpec(FixTraitApplyTransformsInputSpec):
+    input_image = InputMultiObject(
         File(exists=True),
         mandatory=True,
         desc="input time-series as a list of volumes after splitting"
@@ -115,7 +115,7 @@ class _MultiApplyTransformsInputSpec(ApplyTransformsInputSpec):
 
 
 class _MultiApplyTransformsOutputSpec(TraitedSpec):
-    out_files = OutputMultiPath(File(), desc="the output ITKTransform file")
+    out_files = OutputMultiObject(File(), desc="the output ITKTransform file")
     log_cmdline = File(desc="a list of command lines used to apply transforms")
 
 


### PR DESCRIPTION
First step in addressing #553.

The current trait is:

```Python
    transforms = traits.Either(
        InputMultiPath(File(exists=True)),
        "identity",
        argstr="%s",
        mandatory=True,
        desc="transform files: will be applied in reverse order. For "
        "example, the last specified transform will be applied first.",
    ) 
```

This will deserve its own nipype patch, but let's not stand on ceremony, there.