### PR TITLE
FIX: Reportlets would crash in edge condition

### DIFF
--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -174,7 +174,7 @@ def cuts_from_bbox(mask_nii, cuts=3):
         smin, smax = (0, mask_data.shape[ax] - 1)
 
         B = np.argwhere(c > th)
-        if not B.size or B.size < cuts:  # Threshold too high
+        if B.size < cuts:  # Threshold too high
             B = np.argwhere(c > 0)
         if B.size:
             smin, smax = B.min(), B.max()

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -174,7 +174,7 @@ def cuts_from_bbox(mask_nii, cuts=3):
         smin, smax = (0, mask_data.shape[ax] - 1)
 
         B = np.argwhere(c > th)
-        if not B.size:  # Threshold too high
+        if not B.size or B.size < cuts:  # Threshold too high
             B = np.argwhere(c > 0)
         if B.size:
             smin, smax = B.min(), B.max()


### PR DESCRIPTION
The function that calculates the bounding box (and the cuts) to be
represented in reportlets has default thresholds thought out for brain
masks.

When passed a white-matter mask, these thresholds could yield only one
cut (below the required number of cuts).

This patch checkes that the number of cuts are sufficient in all the
cutting planes.

Resolves: #559.