### PR TITLE
ENH: Add units to qform overwrite report

### DIFF
--- a/niworkflows/interfaces/images.py
+++ b/niworkflows/interfaces/images.py
@@ -529,19 +529,21 @@ class ValidateImage(SimpleInterface):
                 diff = np.linalg.inv(qform) @ new_qform
                 trans, rot, _, _ = transforms3d.affines.decompose44(diff)
                 angle = transforms3d.axangles.mat2axangle(rot)[1]
+                xyz_unit = img.header.get_xyzt_units()[0]
+                if xyz_unit == "unknown":
+                    xyz_unit = "mm"
+
                 total_trans = np.sqrt(
                     np.sum(trans * trans)
                 )  # Add angle and total_trans to report
                 warning_txt = "Note on orientation: qform matrix overwritten"
-                description = """\
+                description = f"""\
     <p class="elem-desc">
     The qform has been copied from sform.
-    The difference in angle is {angle:.02g}.
-    The difference in translation is {total_trans:.02g}.
+    The difference in angle is {angle:.02g} radians.
+    The difference in translation is {total_trans:.02g}{xyz_unit}.
     </p>
-    """.format(
-                    angle=angle, total_trans=total_trans
-                )
+    """
             elif qform_code > 0:
                 # qform code indicates the qform is supposed to be valid. Use more stridency.
                 warning_txt = "WARNING - Invalid qform information"


### PR DESCRIPTION
This is a minor improvement to reports that can enter the 20.2.x series of fMRIPrep, so targeting 1.3.x series of niworkflows.

This determines the spatial units of the affine, assuming mm if not coded. I've verified that `transforms3d.axangles.mat2axangle` returns angles in radians.

Addresses nipreps/fmriprep#2287.