### PR TITLE
FIX: Allow omission of <res> for template normalization

### DIFF
--- a/niworkflows/interfaces/mni.py
+++ b/niworkflows/interfaces/mni.py
@@ -84,7 +84,7 @@ class _RobustMNINormalizationInputSpec(BaseInterfaceInputSpec):
     settings = traits.List(File(exists=True), desc="pass on the list of settings files")
     # Resolution of the default template.
     template_spec = traits.DictStrAny(desc="template specifications")
-    template_resolution = traits.Enum(1, 2, desc="(DEPRECATED) template resolution")
+    template_resolution = traits.Enum(1, 2, None, desc="(DEPRECATED) template resolution")
     # Use explicit masking?
     explicit_masking = traits.Bool(
         True,


### PR DESCRIPTION
Since templateflow templates are not required to have `<res>` identifiers, there should be a way to disable searching for one.

EDIT: This is a bit of a hacky solution, especially since `template_resolution` is deprecated. Open to other suggestions.