### PR TITLE
FIX: Use the mask to calculate FOV rather than the fixed image in ` GenerateSamplingReference`

### DIFF
--- a/niworkflows/interfaces/utils.py
+++ b/niworkflows/interfaces/utils.py
@@ -284,7 +284,7 @@ def _gen_reference(
 
         # Get mask into reference space
         masknii = nli.resample_img(
-            fixed_image, target_affine=new_affine, interpolation="nearest"
+            masknii, target_affine=new_affine, interpolation="nearest"
         )
         res_shape = np.array(masknii.shape[:3])
 


### PR DESCRIPTION
Hi guys,

I really like `niworkflows`! I use it to write simple workflows of my own.

For example, I collect MT-weighted images at 7T with an extremely high in-plane resolution of .35 mm. The thickness of the field-of-view, however is only 44 slices, which makes the images not ridiculously big. However, when I registered them to T1w-space and used  `GenerateSamplingReference` to transform them there in their own, native resolution, I noticed that the reference image had 350 slices and the reference image contained 148 million voxels, leading to memory problems.

I think this happened because there is a little bug in the `_gen_ref`-method, that actually does not use the FOV-mask to calculate where to cut off the reference image, but it uses the fixed image that defines the reference space. So, whatever FOV-mask you put in there, it will have no consequence. Can someone check this?

Cheers,
Gilles