### PR TITLE
MAINT: Pin Numpy < 1.20 for Python < 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     nilearn >= 0.2.6, != 0.5.0, != 0.5.1
     nipype >= 1.5.1
     nitransforms >= 20.0.0rc3,<20.2
+    numpy <1.20; python_version < "3.7"
     numpy
     packaging
     pandas


### PR DESCRIPTION
Numpy 1.20 just dropped Python 3.6