### PR TITLE
FIX: Check for in_segm input, not seg_file (typo)

### DIFF
--- a/niworkflows/interfaces/plotting.py
+++ b/niworkflows/interfaces/plotting.py
@@ -62,7 +62,7 @@ class FMRISummary(SimpleInterface):
         fig = fMRIPlot(
             self.inputs.in_func,
             mask_file=self.inputs.in_mask if isdefined(self.inputs.in_mask) else None,
-            seg_file=self.inputs.in_segm if isdefined(self.inputs.seg_file) else None,
+            seg_file=self.inputs.in_segm if isdefined(self.inputs.in_segm) else None,
             spikes_files=[self.inputs.in_spikes_bg],
             tr=self.inputs.tr,
             data=dataframe[["outliers", "DVARS", "FD"]],


### PR DESCRIPTION
Introduced in 1.2.0rc2. in `maint/1.2.x`, to be merged into `maint/1.3.x` and `master` on completion.

Identified by GitHub user @hrswearingen in https://github.com/poldracklab/mriqc/issues/867.