### PR TITLE
MNT: Drop Python 3.6, test setuptools builds, pip installations 

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -23,16 +23,13 @@ jobs:
         
     steps:
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - uses: actions/checkout@v2
       with:
         ssh-key: "${{ secrets.NIPREPS_DEPLOY }}"
-    - name: Fetch all tags (for versioneer to work)
-      if: "!startsWith(github.ref, 'refs/tags/')"
-      run: |
-        /usr/bin/git -c protocol.version=2 fetch --tags --prune --unshallow origin
+        fetch-depth: 0
     - name: Build in confined, updated environment and interpolate version
       run: |
         python -m venv /tmp/buildenv

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,9 +17,6 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        pip: ["pip~=18.1"]
-        # pip: ["pip==10.0.1", "pip~=18.1"]
-        setuptools: ["setuptools==38.4.1", "setuptools"]
         
     steps:
     - name: Set up Python ${{ matrix.python-version }}
@@ -51,7 +48,7 @@ jobs:
       run: |
         python -m venv /tmp/install_sdist
         source /tmp/install_sdist/bin/activate
-        python -m pip install "${{ matrix.pip }}" "${{ matrix.setuptools }}"
+        python -m pip install --upgrade pip wheel
         python -m pip install dist/niworkflows*.tar.gz
         INSTALLED_VERSION=$(python -c 'import niworkflows; print(niworkflows.__version__, end="")')
         echo "VERSION: \"${THISVERSION}\""
@@ -62,32 +59,29 @@ jobs:
       run: |
         python -m venv /tmp/install_wheel
         source /tmp/install_wheel/bin/activate
-        python -m pip install "${{ matrix.pip }}" "${{ matrix.setuptools }}"
+        python -m pip install --upgrade pip wheel
         python -m pip install dist/niworkflows*.whl
         INSTALLED_VERSION=$(python -c 'import niworkflows; print(niworkflows.__version__, end="")')
         echo "INSTALLED: \"${INSTALLED_VERSION}\""
         test "${INSTALLED_VERSION}" = "${THISVERSION}"
 
-    - name: Install in confined environment [setup.py - install]
+    - name: Install in confined environment [pip install .]
       run: |
         python -m venv /tmp/setup_install
         source /tmp/setup_install/bin/activate
-        python -m pip install "${{ matrix.pip }}" "${{ matrix.setuptools }}"
-        python -m pip install numpy scipy "Cython >= 0.28.5" # sklearn needs this
-        python -m pip install scikit-learn  # otherwise it attempts to build it
-        python setup.py install
+        python -m pip install --upgrade pip wheel
+        python -m pip install .
         INSTALLED_VERSION=$(python -c 'import niworkflows; print(niworkflows.__version__, end="")')
         echo "INSTALLED: \"${INSTALLED_VERSION}\""
         test "${INSTALLED_VERSION}" = "${THISVERSION}"
 
-    - name: Install in confined environment [setup.py - develop]
+    - name: Install in confined environment [pip install -e .]
       run: |
         python -m venv /tmp/setup_develop
         source /tmp/setup_develop/bin/activate
-        python -m pip install "${{ matrix.pip }}" "${{ matrix.setuptools }}"
-        python -m pip install numpy scipy "Cython >= 0.28.5" # sklearn needs this
-        python -m pip install scikit-learn  # otherwise it attempts to build it
-        python setup.py develop
+        python -m pip install pip
+        python -m pip install --upgrade pip wheel
+        python -m pip install -e .
         INSTALLED_VERSION=$(python -c 'import niworkflows; print(niworkflows.__version__, end="")')
         echo "INSTALLED: \"${INSTALLED_VERSION}\""
         test "${INSTALLED_VERSION}" = "${THISVERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,9 +121,9 @@ ENV PATH=/usr/local/miniconda/bin:$PATH \
 RUN conda install -y python=3.7.1 \
                      mkl=2018.0.3 \
                      mkl-service \
-                     numpy=1.15.4 \
-                     scipy=1.1.0 \
-                     scikit-learn=0.19.1 \
+                     numpy=1.19 \
+                     scipy=1.5 \
+                     scikit-learn=0.19 \
                      matplotlib=2.2.2 \
                      pandas=0.23.4 \
                      libxml2=2.9.8 \

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,9 +6,9 @@ classifiers =
     Intended Audience :: Science/Research
     Topic :: Scientific/Engineering :: Image Recognition
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 description = NeuroImaging Workflows provides processing tools for magnetic resonance images of the brain.
 license = Apache License, Version 2.0
 license_file = LICENSE
@@ -23,7 +23,7 @@ project_urls =
 url = https://www.nipreps.org
 
 [options]
-python_requires = >= 3.6
+python_requires = >= 3.7
 install_requires =
     attrs
     jinja2
@@ -32,7 +32,6 @@ install_requires =
     nilearn >= 0.2.6, != 0.5.0, != 0.5.1
     nipype >= 1.5.1
     nitransforms >= 20.0.0rc3,<20.2
-    numpy <1.20; python_version < "3.7"
     numpy
     packaging
     pandas


### PR DESCRIPTION
As noted in other discussions, setuptools is aiming to be an installation backend, not an installer, and has no plans to implement various installation PEPs, such as respecting the `PythonRequires` metadata exposed by PyPI.

Therefore I think the recommended installation method needs to be pip. Since we distribute sdists and wheels, we should continue to test those, and those are built with `setuptools` and `wheel`, but we do not need to test against old versions.

We may want to test against old versions of `pip` again, but I think after a year or two of using `pyproject.toml`, we're pretty comfortable that pip can fetch installation dependencies as needed for this project and its dependencies.