### PR TITLE
FIX: Change in *svgutils*' API on 0.3.2 breaks reportlets

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     scikit-image
     scipy
     seaborn
-    svgutils
+    svgutils != 0.3.2
     transforms3d
     templateflow >= 0.6
 test_requires =


### PR DESCRIPTION
A temporary solution to the svgutils problem. With 0.3.3 we will need to revise this again https://github.com/nipreps/niworkflows/issues/595#issuecomment-756129457.

Resolves: #595 .