### PR TITLE
FIX: Address issues with ``RobustAverage`` global signal measurement

### DIFF
--- a/niworkflows/interfaces/bold.py
+++ b/niworkflows/interfaces/bold.py
@@ -17,12 +17,21 @@ LOGGER = logging.getLogger("nipype.interface")
 
 class _NonsteadyStatesDetectorInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc="BOLD fMRI timeseries")
+    nonnegative = traits.Bool(True, usedefault=True,
+                              desc="whether image voxels must be nonnegative")
     n_volumes = traits.Range(
-        value=50,
+        value=40,
         low=10,
         high=200,
         usedefault=True,
         desc="drop volumes in 4D image beyond this timepoint",
+    )
+    zero_dummy_masked = traits.Range(
+        value=20,
+        low=2,
+        high=40,
+        usedefault=True,
+        desc="number of timepoints to average when the number of dummies is zero"
     )
 
 
@@ -43,8 +52,7 @@ class NonsteadyStatesDetector(SimpleInterface):
         img = nb.load(self.inputs.in_file)
 
         ntotal = img.shape[-1] if img.dataobj.ndim == 4 else 1
-
-        self._results["t_mask"] = [False] * ntotal
+        t_mask = np.zeros((ntotal,), dtype=bool)
 
         if ntotal == 1:
             self._results["t_mask"] = [True]
@@ -53,13 +61,22 @@ class NonsteadyStatesDetector(SimpleInterface):
 
         from nipype.algorithms.confounds import is_outlier
 
-        global_signal = np.mean(
-            np.asanyarray(img.dataobj[..., : self.inputs.n_volumes]), axis=(0, 1, 2)
+        data = img.get_fdata(dtype="float32")[..., :self.inputs.n_volumes]
+        # Data can come with outliers showing very high numbers - preemptively prune
+        data = np.clip(
+            data,
+            a_min=0.0 if self.inputs.nonnegative else np.percentile(data, 0.2),
+            a_max=np.percentile(data, 99.8),
         )
+        self._results["n_dummy"] = is_outlier(np.mean(data, axis=(0, 1, 2)))
 
-        ndiscard = is_outlier(global_signal)
-        self._results["n_dummy"] = ndiscard
-        ndiscard = ndiscard or ntotal
-        self._results["t_mask"][:ndiscard] = [True] * ndiscard
+        start = 0
+        stop = self._results["n_dummy"]
+        if stop < 2:
+            stop = min(ntotal, self.inputs.n_volumes)
+            start = max(0, stop - self.inputs.zero_dummy_masked)
+
+        t_mask[start:stop] = True
+        self._results["t_mask"] = t_mask.tolist()
 
         return runtime


### PR DESCRIPTION
This PR introduces two changes into ``RobustAverage``:
- Replaces the global signal calculation - for very skewed datasets, ``np.median(data, axis=(0,1,2))`` very easily contained zeros. In this PR, that is replaced by two steps: 1) removing potential outliers by clipping percentiles; and 2) replacing median by mean.
- Compensation for global signal is done before HMC, with the hope of aiding correction and interpolation.

Fixes the tests currently broken on master.