### PR TITLE
MAINT: Add DS030 dataset, with clipped (55 timepoints) BOLD data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,15 @@ jobs:
             datalad get -J 2 -r -d ds000003/ ds000003/*
 
       - run:
+          name: Get test data from ds000030
+          command: |
+            if [[ ! -d ds000030 ]]; then
+              datalad install -r https://github.com/nipreps-data/ds000030.git
+            fi
+            datalad update -r --merge -d ds000030/
+            datalad get -J 2 -r -d ds000030/ ds000030/sub-10228/func/*
+
+      - run:
           name: Get BIDS test data stub
           command: |
             mkdir -p /tmp/data


### PR DESCRIPTION
This dataset is added to set the ground for testing the new reference
calculation workflow (#601).

Additionally, I will upload derivatives from fMRIPrep with the objective
of setting up some regressions tests for nipreps/fmriprep#2307.

Related: #601, nipreps/fmriprep#2307.