### PR TITLE
ENH: carpet plot tweaks

### DIFF
--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -360,6 +360,8 @@ def _carpet(
     ax1.spines["bottom"].set_visible(False)
     ax1.spines["left"].set_color("none")
     ax1.spines["left"].set_visible(False)
+    if title:
+        ax1.set_title(title)
 
     ax2 = None
     if legend:

--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -151,7 +151,7 @@ def plot_carpet(
     ----------
 
         func : string or nibabel-image object
-            Path to NIfTI or CIFTI BOLD image, or a nibabel-image object 
+            Path to NIfTI or CIFTI BOLD image, or a nibabel-image object
         atlaslabels: ndarray, optional
             A 3D array of integer labels from an atlas, resampled into ``img`` space.
             Required if ``func`` is a NIfTI image.

--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -150,8 +150,8 @@ def plot_carpet(
     Parameters
     ----------
 
-        func : string
-            Path to NIfTI or CIFTI BOLD image
+        func : string or nibabel-image object
+            Path to NIfTI or CIFTI BOLD image, or a nibabel-image object 
         atlaslabels: ndarray, optional
             A 3D array of integer labels from an atlas, resampled into ``img`` space.
             Required if ``func`` is a NIfTI image.
@@ -183,7 +183,7 @@ def plot_carpet(
     epinii = None
     segnii = None
     nslices = None
-    img = nb.load(func)
+    img = nb.load(func) if isinstance(func, str) else func
 
     if isinstance(img, nb.Cifti2Image):
         assert (

--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -159,7 +159,7 @@ def plot_carpet(
             Detrend and standardize the data prior to plotting.
         nskip : int, optional
             Number of volumes at the beginning of the scan marked as nonsteady state.
-            Not used.
+            Only used by volumetric NIfTI.
         size : tuple, optional
             Size of figure.
         subplot : matplotlib Subplot, optional
@@ -226,6 +226,7 @@ def plot_carpet(
     else:  # Volumetric NIfTI
         img_nii = check_niimg_4d(img, dtype="auto",)
         func_data = _safe_get_data(img_nii, ensure_finite=True)
+        func_data = func_data[..., nskip:]
         ntsteps = func_data.shape[-1]
         data = func_data[atlaslabels > 0].reshape(-1, ntsteps)
         oseg = atlaslabels[atlaslabels > 0].reshape(-1)

--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -344,7 +344,7 @@ def _carpet(
     interval = max((int(data.shape[-1] + 1) // 10, int(data.shape[-1] + 1) // 5, 1))
     xticks = list(range(0, data.shape[-1])[::interval])
     if notr:
-        xlabel = "time (frame #)"
+        xlabel = "time-points (index)"
         xticklabels = [round(xtick) for xtick in xticks]
     else:
         xlabel = "time (s)"

--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -345,7 +345,7 @@ def _carpet(
     ax1.set_xticks(xticks)
     ax1.set_xlabel("time (frame #)" if notr else "time (s)")
     labels = tr * (np.array(xticks))
-    ax1.set_xticklabels(["%.02f" % t for t in labels.tolist()], fontsize=5)
+    ax1.set_xticklabels(["%.02f" % t for t in labels.tolist()])
 
     # Remove and redefine spines
     for side in ["top", "right"]:

--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -266,6 +266,7 @@ def plot_carpet(
         nslices=nslices,
         tr=tr,
         subplot=subplot,
+        legend=legend,
         title=title,
         output_file=output_file,
     )

--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -343,10 +343,15 @@ def _carpet(
     # Set 10 frame markers in X axis
     interval = max((int(data.shape[-1] + 1) // 10, int(data.shape[-1] + 1) // 5, 1))
     xticks = list(range(0, data.shape[-1])[::interval])
+    if notr:
+        xlabel = "time (frame #)"
+        xticklabels = [round(xtick) for xtick in xticks]
+    else:
+        xlabel = "time (s)"
+        xticklabels = ["%.02f" % (tr * xtick) for xtick in xticks]
     ax1.set_xticks(xticks)
-    ax1.set_xlabel("time (frame #)" if notr else "time (s)")
-    labels = tr * (np.array(xticks))
-    ax1.set_xticklabels(["%.02f" % t for t in labels.tolist()])
+    ax1.set_xlabel(xlabel)
+    ax1.set_xticklabels(xticklabels)
 
     # Remove and redefine spines
     for side in ["top", "right"]:


### PR DESCRIPTION
This PR is a mix of fixes and enhancements to `viz.plot_carpet`. Most of the enhancements are based on personal preference so they can be dropped if desired.

**Fixes**

- Legend should now show up if `legend = True`
  + The legend argument was not getting passed from `carpet_plot()` to `_carpet()`
- Title should now show up if `title` argument is specified

**Enhancements**

- The `nskip` argument should now work for NIfTI inputs
  + Looks like it's trivial to implement this for CIFTI as well, but I don't use them, so I didn't touch it
- Tick formatting
  + If the xticks are frame numbers, then they will be printed as integers instead of decimals
  + Xticks now use the default font size
     + This prevents a clash with user-defined matplotlib configuration
- The input data can now be a nibabel-image. A path (as a string) is still acceptable.
  + This is convenient because I can pre-process the data and then plot it directly without the i/o overhead 