### PR TITLE
FIX: Bump to later release of svgutils, small API change

### DIFF
--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -408,8 +408,8 @@ def _compose_view(bg_svgs, fg_svgs, ref=0):
     else:
         newroots = roots
     fig.append(newroots)
-    fig.root.attrib.pop("width")
-    fig.root.attrib.pop("height")
+    fig.root.attrib.pop("width", None)
+    fig.root.attrib.pop("height", None)
     fig.root.set("preserveAspectRatio", "xMidYMid meet")
 
     with TemporaryDirectory() as tmpdirname:

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -393,7 +393,7 @@ def _compose_view(bg_svgs, fg_svgs, ref=0):
 
     yoffset = 0
     for i, r in enumerate(roots):
-        r.moveto(0, yoffset, scale=scales[i])
+        r.moveto(0, yoffset, scale_x=scales[i])
         if i == (nsvgs - 1):
             yoffset = 0
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     scikit-learn
     scipy
     seaborn
-    svgutils == 0.3.1  # https://github.com/nipreps/niworkflows/issues/595
+    svgutils >= 0.3.4
     transforms3d
     templateflow >= 0.6
 test_requires =


### PR DESCRIPTION
Originally discussed in https://github.com/nipreps/niworkflows/issues/595#issuecomment-758185278

Sets the minimum version of `svgutils` to 1.3.4 to avoid `try/except` shenanigans.
