### PR TITLE
FIX: Ensure IntensityClip input is a 3D file

### DIFF
--- a/niworkflows/interfaces/nibabel.py
+++ b/niworkflows/interfaces/nibabel.py
@@ -369,7 +369,7 @@ class GenerateSamplingReference(SimpleInterface):
 
 class _IntensityClipInputSpec(BaseInterfaceInputSpec):
     in_file = File(
-        exists=True, mandatory=True, desc="file which intensity will be clipped"
+        exists=True, mandatory=True, desc="3D file which intensity will be clipped"
     )
     p_min = traits.Float(35.0, usedefault=True, desc="percentile for the lower bound")
     p_max = traits.Float(99.98, usedefault=True, desc="percentile for the upper bound")
@@ -519,7 +519,8 @@ def _advanced_clip(
     out_file = (Path(newpath or "") / "clipped.nii.gz").absolute()
 
     # Load data
-    img = nb.load(in_file)
+    img = nb.squeeze_image(nb.load(in_file))
+    assert len(img.shape) == 3, "Not a 3D image"
     data = img.get_fdata(dtype="float32")
 
     # Calculate stats on denoised version, to preempt outliers from biasing

--- a/niworkflows/interfaces/nibabel.py
+++ b/niworkflows/interfaces/nibabel.py
@@ -520,7 +520,8 @@ def _advanced_clip(
 
     # Load data
     img = nb.squeeze_image(nb.load(in_file))
-    assert len(img.shape) == 3, "Not a 3D image"
+    if len(img.shape) != 3:
+        raise RuntimeError(f"<{in_file}> is not a 3D file.")
     data = img.get_fdata(dtype="float32")
 
     # Calculate stats on denoised version, to preempt outliers from biasing


### PR DESCRIPTION
When testing this new interface in nibabies, an image with shape (x, y, z, 1) caused a crash. The problematic line was 
`denoised = ndimage.median_filter(data, footprint=ball(3))`, which may be currently limiting to only 3D files.

This PR squeezes whatever input we get and adds a quick assertion to verify the image is 3D. We may want to revisit this if there are plans to also run on 4D files.