### PR TITLE
MNT: Drop gh-pages history, reducing repository size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ docs_deploy: &docs
     - run:
         name: Install and configure dependencies
         command: |
-          npm install -g --silent gh-pages@2.0.1
+          npm install -g --silent gh-pages@3.0.0
           git config user.email "nipreps@gmail.com"
           git config user.name "Documentation Push"
     - add_ssh_keys:
@@ -26,7 +26,7 @@ docs_deploy: &docs
           - "c8:a8:55:7d:1e:08:92:c2:86:29:7b:b4:4b:88:24:51"
     - run:
         name: Deploy docs to gh-pages branch
-        command: gh-pages --dotfiles --message "doc(update) [skip ci]" --dist docs/_build/html
+        command: gh-pages --no-history --dotfiles --message "doc(update) [skip ci]" --dist docs/_build/html
 
 version: 2
 jobs:


### PR DESCRIPTION
Currently:

```Shell
$ time git clone https://github.com/nipreps/niworkflows.git           
Cloning into 'niworkflows'...
remote: Enumerating objects: 17457, done.
remote: Counting objects: 100% (17457/17457), done.
remote: Compressing objects: 100% (2299/2299), done.
remote: Total 890088 (delta 15964), reused 16084 (delta 14654), pack-reused 872631
Receiving objects: 100% (890088/890088), 1.14 GiB | 8.75 MiB/s, done.
Resolving deltas: 100% (801905/801905), done.
git clone https://github.com/nipreps/niworkflows.git  225.60s user 34.76s system 128% cpu 3:22.09 total
$ du -sh niworkflows 
1.3G	niworkflows
```

Just checking out master:

```Shell
$ time git clone --single-branch https://github.com/nipreps/niworkflows.git
Cloning into 'niworkflows'...
remote: Enumerating objects: 70, done.
remote: Counting objects: 100% (70/70), done.
remote: Compressing objects: 100% (59/59), done.
remote: Total 11181 (delta 12), reused 63 (delta 11), pack-reused 11111
Receiving objects: 100% (11181/11181), 286.47 MiB | 9.25 MiB/s, done.
Resolving deltas: 100% (7775/7775), done.
git clone --single-branch https://github.com/nipreps/niworkflows.git  15.85s user 8.86s system 76% cpu 32.486 total
$ du -sh niworkflows
386M	niworkflows
```

Takes advantage of https://github.com/tschaub/gh-pages/pull/277. Using 3.0.0 to avoid https://github.com/tschaub/gh-pages/issues/354, affecting 3.1.0.