### PR TITLE
FIX: Readd sbref_file input to reference volume interface

### DIFF
--- a/niworkflows/func/util.py
+++ b/niworkflows/func/util.py
@@ -241,7 +241,7 @@ methodology of *fMRIPrep*.
     workflow.connect([
         (inputnode, val_sbref, [(("sbref_file", listify), "in_file")]),
         (val_sbref, merge_sbrefs, [("out_file", "in_files")]),
-        (merge_sbrefs, gen_avg, [("out_file", "sbref_file")]),
+        (merge_sbrefs, gen_avg, [("out_file", "in_file")]),
     ])
     # fmt: on
 

--- a/niworkflows/interfaces/images.py
+++ b/niworkflows/interfaces/images.py
@@ -191,7 +191,9 @@ class IntraModalMerge(SimpleInterface):
 
 class _RobustAverageInputSpec(BaseInterfaceInputSpec):
     in_file = File(
-        exists=True, mandatory=True, desc="A 4D file to average through the last axis"
+        exists=True,
+        mandatory=True,
+        desc="Either a 3D reference or 4D file to average through the last axis"
     )
     t_mask = traits.List(traits.Bool, desc="List of selected timepoints to be averaged")
     mc_method = traits.Enum(


### PR DESCRIPTION
Currently, the `init_bold_reference_wf` is failing at https://github.com/nipreps/niworkflows/blob/fa56d3048f6a9972f4008ad32f40088e4aaba94b/niworkflows/func/util.py#L241-L245

~~This PR adds a new input `sbref_file` to `RobustAverage`.~~
This PR sets the merged sbref_file as the in_file and leverages existing logic to handle 3D inputs.