### PR TITLE
FIX: Purge removed `--disable` flag from svgo call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ WORKDIR /home/niworkflows
 ENV HOME="/home/niworkflows"
 
 # Installing SVGO
-RUN npm install -g svgo~2
+RUN npm install -g svgo@^2
 
 # Installing WEBP tools
 RUN curl -sSLO "http://downloads.webmproject.org/releases/webp/libwebp-0.5.2-linux-x86-64.tar.gz" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ WORKDIR /home/niworkflows
 ENV HOME="/home/niworkflows"
 
 # Installing SVGO
-RUN npm install -g svgo
+RUN npm install -g svgo~2
 
 # Installing WEBP tools
 RUN curl -sSLO "http://downloads.webmproject.org/releases/webp/libwebp-0.5.2-linux-x86-64.tar.gz" && \

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -44,7 +44,7 @@ def svg_compress(image, compress="auto"):
 
     # Compress the SVG file using SVGO
     if compress:
-        cmd = "svgo -i - -o - -q -p 3 --pretty --disable=cleanupNumericValues"
+        cmd = "svgo -i - -o - -q -p 3 --pretty"
         try:
             pout = subprocess.run(
                 cmd,


### PR DESCRIPTION
svgo 2.x dropped support for CLI plugin alteration.
We could generate a JSON config with this option, but
the changes are so miniscule we can likely just drop this flag.

This PR also pins the svgo version in the Dockerfile to the 2.x series.