### PR TITLE
FIX: Limit memory usage in EstimateReferenceImage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ WORKDIR /home/niworkflows
 ENV HOME="/home/niworkflows"
 
 # Installing SVGO
-RUN npm install -g svgo
+RUN npm install -g svgo@^2
 
 # Installing WEBP tools
 RUN curl -sSLO "http://downloads.webmproject.org/releases/webp/libwebp-0.5.2-linux-x86-64.tar.gz" && \

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -484,7 +484,7 @@ class EstimateReferenceImage(SimpleInterface):
         # Build the nibabel spatial image we will work with
         ref_im = []
         for im_i in ref_input:
-            max_new_volumes = 40 - len(ref_im)
+            max_new_volumes = 50 - len(ref_im)
             if max_new_volumes <= 0:
                 break
             nib_i = nb.squeeze_image(nb.load(im_i))

--- a/niworkflows/interfaces/registration.py
+++ b/niworkflows/interfaces/registration.py
@@ -484,11 +484,14 @@ class EstimateReferenceImage(SimpleInterface):
         # Build the nibabel spatial image we will work with
         ref_im = []
         for im_i in ref_input:
+            max_new_volumes = 40 - len(ref_im)
+            if max_new_volumes <= 0:
+                break
             nib_i = nb.squeeze_image(nb.load(im_i))
             if nib_i.dataobj.ndim == 3:
                 ref_im.append(nib_i)
             elif nib_i.dataobj.ndim == 4:
-                ref_im += nb.four_to_three(nib_i)
+                ref_im += nb.four_to_three(nib_i.slicer[..., :max_new_volumes])
         ref_im = nb.squeeze_image(nb.concat_images(ref_im))
 
         # Volumes to discard only makes sense with BOLD inputs.

--- a/niworkflows/interfaces/tests/test_registration.py
+++ b/niworkflows/interfaces/tests/test_registration.py
@@ -6,7 +6,7 @@ from nipype.interfaces import afni
 from niworkflows.interfaces.registration import EstimateReferenceImage
 
 
-@pytest.mark.parametrize("n_vols", (1, 2, 40, 41))
+@pytest.mark.parametrize("n_vols", (1, 2, 50, 51))
 @pytest.mark.skipif(afni.Info.version() is None, reason="Realignment requires 3dvolreg")
 def test_EstimateReferenceImage_truncation(tmp_path, n_vols):
     # Smoke test to ensure that logic for limiting loaded volumes is followed

--- a/niworkflows/interfaces/tests/test_registration.py
+++ b/niworkflows/interfaces/tests/test_registration.py
@@ -1,0 +1,36 @@
+import pytest
+import numpy as np
+import nibabel as nb
+from nipype.pipeline import engine as pe
+from nipype.interfaces import afni
+from niworkflows.interfaces.registration import EstimateReferenceImage
+
+
+@pytest.mark.parametrize("n_vols", (1, 2, 40, 41))
+@pytest.mark.skipif(afni.Info.version() is None, reason="Realignment requires 3dvolreg")
+def test_EstimateReferenceImage_truncation(tmp_path, n_vols):
+    # Smoke test to ensure that logic for limiting loaded volumes is followed
+    data = np.zeros((12, 12, 12, n_vols), dtype="f4")
+    data[3:9, 3:9, 3:9, :] = 1
+
+    in_file = str(tmp_path / "orig.nii")
+
+    nb.Nifti1Image(data, np.eye(4)).to_filename(in_file)
+
+    # One input
+    genref = pe.Node(
+        EstimateReferenceImage(in_file=in_file), name="genref", base_dir=tmp_path
+    )
+    # Single volume implies sbref
+    if n_vols == 1:
+        genref.inputs.sbref_file = in_file
+
+    genref.run()
+
+    # Two inputs... only sbref permits multiple files
+    genref2 = pe.Node(
+        EstimateReferenceImage(in_file=in_file), name="genref", base_dir=tmp_path
+    )
+    genref2.inputs.sbref_file = [in_file, in_file]
+
+    genref2.run()

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -46,7 +46,7 @@ def svg_compress(image, compress="auto"):
 
     # Compress the SVG file using SVGO
     if compress:
-        cmd = "svgo -i - -o - -q -p 3 --pretty --disable=cleanupNumericValues"
+        cmd = "svgo -i - -o - -q -p 3 --pretty"
         try:
             pout = subprocess.run(
                 cmd,


### PR DESCRIPTION
Fixes #628. At least partially. If we're splitting and concatenating 900MB of data, it seems plausible we could double our usage to 1.8GB. Maybe should call it 2GB to be safe?