### PR TITLE
ENH: add rodent-specific adaption for B-spline

### DIFF
--- a/niworkflows/anat/ants.py
+++ b/niworkflows/anat/ants.py
@@ -559,10 +559,10 @@ def init_atropos_wf(
     bspline_fitting_distance : float
         The size of the b-spline mesh grid elements, in mm (default: 200)
     adaptive_bspline_grid : :obj:`bool`
-        If true, defines the number of b-spline mesh grid elements in each dimension rather
+        If true, defines the number of B-Spline mesh grid elements in each dimension rather
         than using the isotropic distance given in ``bspline_fitting_distance``.
     n4_iter : :obj:`int`
-        The number of b-spline iterations (default: 5). Fewer (e.g. 4) are recommended
+        The number of B-Spline fitting iterations (default: 5). Fewer (e.g. 4) are recommended
         for rodents and other non-human/non-adult cases.
     wm_prior : :obj:`bool`
         Whether the WM posterior obtained with ATROPOS should be regularized with a prior

--- a/niworkflows/anat/ants.py
+++ b/niworkflows/anat/ants.py
@@ -763,14 +763,15 @@ def init_atropos_wf(
             dimension=3,
             save_bias=True,
             copy_header=True,
+            n_iterations=[50]*n4_iter,
             convergence_threshold=1e-7,
             shrink_factor=4,
+            bspline_fitting_distance=bspline_fitting_distance,
         ),
         n_procs=omp_nthreads,
         name="inu_n4_final",
         iterfield=["input_image"],
     )
-    inu_n4_final.inputs.n_iterations = [50] * n4_iter
 
     try:
         inu_n4_final.inputs.rescale_intensities = True
@@ -894,9 +895,6 @@ def init_atropos_wf(
             (bspline_grid, inu_n4_final, [("out", "args")])
         ])
         # fmt:on
-    else:
-        # set INU bspline grid based on isotropic distance
-        inu_n4_final.inputs.bspline_fitting_distance = bspline_fitting_distance
 
     return wf
 

--- a/niworkflows/anat/ants.py
+++ b/niworkflows/anat/ants.py
@@ -507,8 +507,8 @@ def init_atropos_wf(
     padding=10,
     in_segmentation_model=tuple(ATROPOS_MODELS["T1w"].values()),
     bspline_fitting_distance=200,
-    use_bspline_grid=False,
-    min_n4_iter=False,
+    adaptive_bspline_grid=False,
+    n4_iter=5,
     wm_prior=False,
 ):
     """
@@ -558,12 +558,12 @@ def init_atropos_wf(
         ``(4,4,2,3)`` uses K=4, CSF=4, GM=2, WM=3.
     bspline_fitting_distance : float
         The size of the b-spline mesh grid elements, in mm (default: 200)
-    use_bspline_grid : :obj:`bool`
+    adaptive_bspline_grid : :obj:`bool`
         If true, defines the number of b-spline mesh grid elements in each dimension rather
         than using the isotropic distance given in ``bspline_fitting_distance``.
-    min_n4_iter : :obj:`bool`
-        If ``True``, reduces the number of b-spline iterations from 5 to 4. This use-case
-        is intended for rodents and other non-human/non-adult cases.
+    n4_iter : :obj:`int`
+        The number of b-spline iterations (default: 5). Fewer (e.g. 4) are recommended
+        for rodents and other non-human/non-adult cases.
     wm_prior : :obj:`bool`
         Whether the WM posterior obtained with ATROPOS should be regularized with a prior
         map (typically, mapped from the template). When ``wm_prior`` is ``True`` the input
@@ -770,7 +770,7 @@ def init_atropos_wf(
         name="inu_n4_final",
         iterfield=["input_image"],
     )
-    inu_n4_final.inputs.n_iterations = [50] * (5 - min_n4_iter)
+    inu_n4_final.inputs.n_iterations = [50] * n4_iter
 
     try:
         inu_n4_final.inputs.rescale_intensities = True
@@ -883,14 +883,14 @@ def init_atropos_wf(
         ])
         # fmt: on
 
-    if use_bspline_grid:
+    if adaptive_bspline_grid:
         # set INU bspline grid based on image shape
         from ..utils.images import _bspline_grid
-        bspline_grid = pe.MapNode(niu.Function(function=_bspline_grid), name="bspline_grid")
+        bspline_grid = pe.Node(niu.Function(function=_bspline_grid), name="bspline_grid")
 
         # fmt:off
         wf.connect([
-            (inputnode, bspline_grid, [("in_files", "in_file")]),
+            (inputnode, bspline_grid, [(("in_files", _pop), "in_file")]),
             (bspline_grid, inu_n4_final, [("out", "args")])
         ])
         # fmt:on
@@ -906,8 +906,6 @@ def init_n4_only_wf(
     atropos_refine=True,
     atropos_use_random_seed=True,
     bids_suffix="T1w",
-    use_bspline_grid=False,
-    min_n4_iter=False,
     mem_gb=3.0,
     name="n4_only_wf",
     omp_nthreads=None,
@@ -948,11 +946,6 @@ def init_n4_only_wf(
     atropos_model : tuple or None
         Allows to specify a particular segmentation model, overwriting
         the defaults based on ``bids_suffix``
-    use_bspline_grid : :obj:`bool`
-        If true, defines the number of b-spline mesh grid elements in each dimension.
-    min_n4_iter : :obj:`bool`
-        If ``True``, reduces the number of b-spline iterations from 5 to 4. This use-case
-        is intended for rodents and other non-human/non-adult cases.
     name : str, optional
         Workflow name (default: ``'n4_only_wf'``).
 
@@ -1015,14 +1008,15 @@ def init_n4_only_wf(
             dimension=3,
             save_bias=True,
             copy_header=True,
+            n_iterations=[50] * 5,
             convergence_threshold=1e-7,
             shrink_factor=4,
+            bspline_fitting_distance=200,
         ),
         n_procs=omp_nthreads,
         name="inu_n4_final",
         iterfield=["input_image"],
     )
-    inu_n4_final.inputs.n_iterations = [50] * (5 - min_n4_iter)
 
     # Check ANTs version
     try:
@@ -1074,22 +1068,6 @@ def init_n4_only_wf(
             ]),
         ])
         # fmt: on
-
-    if use_bspline_grid:
-        # set INU bspline grid based on voxel size
-        from ..utils.images import _bspline_grid
-        bspline_grid = pe.MapNode(niu.Function(function=_bspline_grid), name="bspline_grid")
-
-        # fmt:off
-        wf.connect([
-            (inputnode, bspline_grid, [("in_files", "in_file")]),
-            (bspline_grid, inu_n4_final, [("out", "args")])
-        ])
-        # fmt:on
-    else:
-        # set INU bspline grid based on isotropic distance
-        inu_n4_final.inputs.bspline_fitting_distance = 200
-
     return wf
 
 

--- a/niworkflows/anat/ants.py
+++ b/niworkflows/anat/ants.py
@@ -508,6 +508,7 @@ def init_atropos_wf(
     in_segmentation_model=tuple(ATROPOS_MODELS["T1w"].values()),
     bspline_fitting_distance=200,
     wm_prior=False,
+    rodent=False,
 ):
     """
     Create an ANTs' ATROPOS workflow for brain tissue segmentation.
@@ -755,10 +756,8 @@ def init_atropos_wf(
             dimension=3,
             save_bias=True,
             copy_header=True,
-            n_iterations=[50] * 5,
             convergence_threshold=1e-7,
             shrink_factor=4,
-            bspline_fitting_distance=bspline_fitting_distance,
         ),
         n_procs=omp_nthreads,
         name="inu_n4_final",
@@ -875,6 +874,26 @@ def init_atropos_wf(
             (apply_wm_prior, inu_n4_final, [("out", "weight_image")]),
         ])
         # fmt: on
+    
+    # rodent-specific N4 settings
+    if rodent:
+        from ..utils.images import _bspline_grid
+        # fewer iterations of N4
+        inu_n4_final.inputs.n_iterations=[50] * 4
+
+        # set INU bspline grid based on voxel size
+        bspline_grid = pe.MapNode(niu.Function(function=_bspline_grid), name="bspline_grid")
+        
+        # fmt:off
+        wf.connect([
+            (inputnode, bspline_grid, [("in_files", "in_file")]),
+            (bspline_grid, inu_n4_final, [("out", "args")])
+        ])
+        # fmt:on
+    else:
+        inu_n4_final.inputs.n_iterations=[50] * 5
+        inu_n4_final.inputs.bspline_fitting_distance=bspline_fitting_distance
+
     return wf
 
 
@@ -883,6 +902,7 @@ def init_n4_only_wf(
     atropos_refine=True,
     atropos_use_random_seed=True,
     bids_suffix="T1w",
+    rodent=False,
     mem_gb=3.0,
     name="n4_only_wf",
     omp_nthreads=None,
@@ -1045,6 +1065,24 @@ def init_n4_only_wf(
             ]),
         ])
         # fmt: on
+    
+    # rodent-specific N4 settings
+    if rodent:
+        from ..utils.images import _bspline_grid
+        # fewer iterations of N4
+        inu_n4_final.inputs.n_iterations=[50] * 4
+
+        # set INU bspline grid based on voxel size
+        bspline_grid = pe.MapNode(niu.Function(function=_bspline_grid), name="bspline_grid")
+        
+        # fmt:off
+        wf.connect([
+            (inputnode, bspline_grid, [("in_files", "in_file")]),
+            (bspline_grid, inu_n4_final, [("out", "args")])
+        ])
+        # fmt:on
+    else:
+        inu_n4_final.inputs.n_iterations=[50] * 5
 
     return wf
 

--- a/niworkflows/anat/ants.py
+++ b/niworkflows/anat/ants.py
@@ -874,16 +874,16 @@ def init_atropos_wf(
             (apply_wm_prior, inu_n4_final, [("out", "weight_image")]),
         ])
         # fmt: on
-    
+
     # rodent-specific N4 settings
     if rodent:
         from ..utils.images import _bspline_grid
         # fewer iterations of N4
-        inu_n4_final.inputs.n_iterations=[50] * 4
+        inu_n4_final.inputs.n_iterations = [50] * 4
 
         # set INU bspline grid based on voxel size
         bspline_grid = pe.MapNode(niu.Function(function=_bspline_grid), name="bspline_grid")
-        
+
         # fmt:off
         wf.connect([
             (inputnode, bspline_grid, [("in_files", "in_file")]),
@@ -891,8 +891,8 @@ def init_atropos_wf(
         ])
         # fmt:on
     else:
-        inu_n4_final.inputs.n_iterations=[50] * 5
-        inu_n4_final.inputs.bspline_fitting_distance=bspline_fitting_distance
+        inu_n4_final.inputs.n_iterations = [50] * 5
+        inu_n4_final.inputs.bspline_fitting_distance = bspline_fitting_distance
 
     return wf
 
@@ -1065,16 +1065,16 @@ def init_n4_only_wf(
             ]),
         ])
         # fmt: on
-    
+
     # rodent-specific N4 settings
     if rodent:
         from ..utils.images import _bspline_grid
         # fewer iterations of N4
-        inu_n4_final.inputs.n_iterations=[50] * 4
+        inu_n4_final.inputs.n_iterations = [50] * 4
 
         # set INU bspline grid based on voxel size
         bspline_grid = pe.MapNode(niu.Function(function=_bspline_grid), name="bspline_grid")
-        
+
         # fmt:off
         wf.connect([
             (inputnode, bspline_grid, [("in_files", "in_file")]),
@@ -1082,7 +1082,7 @@ def init_n4_only_wf(
         ])
         # fmt:on
     else:
-        inu_n4_final.inputs.n_iterations=[50] * 5
+        inu_n4_final.inputs.n_iterations = [50] * 5
 
     return wf
 

--- a/niworkflows/utils/images.py
+++ b/niworkflows/utils/images.py
@@ -324,3 +324,19 @@ def nii_ones_like(in_file, value, dtype, newpath=None):
     nii.to_filename(out_file)
 
     return out_file
+
+def _bspline_grid(in_file):
+    """Estimate B-Spline fitting distance grid using the number of slices of ``in_file``."""
+    import nibabel as nb
+    import numpy as np
+
+    img = nb.load(in_file)
+    slices = img.header.get_data_shape()
+    # find ratio of slices in each dimension wrt dimension with most slices
+    ratio = [s / slices[np.argmax(slices)] for s in slices]
+    # find common factor for the dimensions with the most and least slices
+    ratio_factor = ratio[np.argmax(ratio)] / ratio[np.argmin(ratio)]
+    # convert ratio to integers
+    mesh_res = [f"{round(i * ratio_factor)}" for i in ratio]
+    # return string for command line call
+    return f"-b [{'x'.join(mesh_res)}]"

--- a/niworkflows/utils/images.py
+++ b/niworkflows/utils/images.py
@@ -327,9 +327,13 @@ def nii_ones_like(in_file, value, dtype, newpath=None):
 
 
 def _bspline_grid(in_file):
-    """Estimate B-Spline fitting distance grid using the number of slices of ``in_file``.
+    """
+    Estimate B-Spline fitting distance grid using the number of slices of ``in_file``.
+
     Using slice number to determine grid sparsity is inspired by the conversation found at
-    https://itk.org/pipermail/community/2014-February/005036.html"""
+    https://itk.org/pipermail/community/2014-February/005036.html
+    
+    """
     import nibabel as nb
     import numpy as np
     import math

--- a/niworkflows/utils/images.py
+++ b/niworkflows/utils/images.py
@@ -327,7 +327,9 @@ def nii_ones_like(in_file, value, dtype, newpath=None):
 
 
 def _bspline_grid(in_file):
-    """Estimate B-Spline fitting distance grid using the number of slices of ``in_file``."""
+    """Estimate B-Spline fitting distance grid using the number of slices of ``in_file``.
+    Using slice number to determine grid sparsity is inspired by the conversation found at
+    https://itk.org/pipermail/community/2014-February/005036.html"""
     import nibabel as nb
     import numpy as np
     import math
@@ -335,9 +337,8 @@ def _bspline_grid(in_file):
     img = nb.load(in_file)
     zooms = img.header.get_zooms()[:3]
     # find extent of each dimension wrt voxel sizes
-    extent = (np.array(img.shape[:3]) - 1) * zooms
+    extent = np.array(img.shape[:3]) * zooms
     # convert ratio to integers
     retval = [f"{math.ceil(i / extent[np.argmin(extent)])}" for i in extent]
     # return string for command line call
     return f"-b [{'x'.join(retval)}]"
-

--- a/niworkflows/utils/images.py
+++ b/niworkflows/utils/images.py
@@ -330,14 +330,14 @@ def _bspline_grid(in_file):
     """Estimate B-Spline fitting distance grid using the number of slices of ``in_file``."""
     import nibabel as nb
     import numpy as np
+    import math
 
     img = nb.load(in_file)
-    slices = img.header.get_data_shape()
-    # find ratio of slices in each dimension wrt dimension with most slices
-    ratio = [s / slices[np.argmax(slices)] for s in slices]
-    # find common factor for the dimensions with the most and least slices
-    ratio_factor = ratio[np.argmax(ratio)] / ratio[np.argmin(ratio)]
+    zooms = img.header.get_zooms()[:3]
+    # find extent of each dimension wrt voxel sizes
+    extent = (np.array(img.shape[:3]) - 1) * zooms
     # convert ratio to integers
-    mesh_res = [f"{round(i * ratio_factor)}" for i in ratio]
+    retval = [f"{math.ceil(i / extent[np.argmin(extent)])}" for i in extent]
     # return string for command line call
-    return f"-b [{'x'.join(mesh_res)}]"
+    return f"-b [{'x'.join(retval)}]"
+

--- a/niworkflows/utils/images.py
+++ b/niworkflows/utils/images.py
@@ -325,6 +325,7 @@ def nii_ones_like(in_file, value, dtype, newpath=None):
 
     return out_file
 
+
 def _bspline_grid(in_file):
     """Estimate B-Spline fitting distance grid using the number of slices of ``in_file``."""
     import nibabel as nb

--- a/niworkflows/workflows/epi/refmap.py
+++ b/niworkflows/workflows/epi/refmap.py
@@ -233,11 +233,11 @@ def init_epi_reference_wf(
     if rodent:
         from ...utils.images import _bspline_grid
         # fewer iterations of N4
-        n4_avgs.inputs.n_iterations=[50] * 4
+        n4_avgs.inputs.n_iterations = [50] * 4
 
         # set INU bspline grid based on voxel size
         bspline_grid = pe.Node(niu.Function(function=_bspline_grid), name="bspline_grid")
-        
+
         # fmt:off
         wf.connect([
             (validate_nii, bspline_grid, [("out_file", "in_file")]),
@@ -245,7 +245,7 @@ def init_epi_reference_wf(
         ])
         # fmt:on
     else:
-        n4_avgs.inputs.n_iterations=[50] * 5
+        n4_avgs.inputs.n_iterations = [50] * 5
 
     return wf
 

--- a/niworkflows/workflows/epi/refmap.py
+++ b/niworkflows/workflows/epi/refmap.py
@@ -34,7 +34,8 @@ DEFAULT_MEMORY_MIN_GB = 0.01
 def init_epi_reference_wf(
     omp_nthreads,
     auto_bold_nss=False,
-    rodent=False,
+    use_bspline_grid=False,
+    min_n4_iter=False,
     name="epi_reference_wf",
 ):
     """
@@ -85,9 +86,12 @@ def init_epi_reference_wf(
         If ``True``, determines nonsteady states in the beginning of the timeseries
         and selects them for the averaging of each run.
         IMPORTANT: this option applies only to BOLD EPIs.
-    rodent : :obj:`bool`
-        If ``True``, determines whether to calculate B-spline fitting distance from
-        voxel sizes and feeds them into N4BiasFieldCorrection.
+    use_bspline_grid : :obj:`bool`
+        If ``True``, determines the number of b-spline grid elements from data shape
+        and feeds them into N4BiasFieldCorrection, rather than setting an isotropic distance.
+    min_n4_iter : :obj:`bool`
+        If ``True``, reduces the number of b-spline iterations from 5 to 4. This use-case
+        is intended for rodents and other non-human/non-adult cases.
 
     Inputs
     ------
@@ -230,11 +234,9 @@ def init_epi_reference_wf(
         wf.connect(inputnode, "t_masks", per_run_avgs, "t_mask")
 
     # rodent-specific N4 settings
-    if rodent:
+    n4_avgs.inputs.n_iterations = [50] * (5 - min_n4_iter)
+    if use_bspline_grid:
         from ...utils.images import _bspline_grid
-        # fewer iterations of N4
-        n4_avgs.inputs.n_iterations = [50] * 4
-
         # set INU bspline grid based on voxel size
         bspline_grid = pe.Node(niu.Function(function=_bspline_grid), name="bspline_grid")
 
@@ -244,8 +246,6 @@ def init_epi_reference_wf(
             (bspline_grid, n4_avgs, [("out", "args")])
         ])
         # fmt:on
-    else:
-        n4_avgs.inputs.n_iterations = [50] * 5
 
     return wf
 

--- a/niworkflows/workflows/epi/refmap.py
+++ b/niworkflows/workflows/epi/refmap.py
@@ -87,10 +87,10 @@ def init_epi_reference_wf(
         and selects them for the averaging of each run.
         IMPORTANT: this option applies only to BOLD EPIs.
     adaptive_bspline_grid : :obj:`bool`
-        If ``True``, determines the number of b-spline grid elements from data shape
+        If ``True``, determines the number of B-Spline grid elements from data shape
         and feeds them into N4BiasFieldCorrection, rather than setting an isotropic distance.
     n4_iter : :obj:`int`
-        The number of b-spline iterations (default: 5). Fewer (e.g. 4) are recommended
+        The number of B-Spline fitting iterations (default: 5). Fewer (e.g. 4) are recommended
         for rodents and other non-human/non-adult cases.
 
     Inputs

--- a/niworkflows/workflows/epi/refmap.py
+++ b/niworkflows/workflows/epi/refmap.py
@@ -34,8 +34,8 @@ DEFAULT_MEMORY_MIN_GB = 0.01
 def init_epi_reference_wf(
     omp_nthreads,
     auto_bold_nss=False,
-    use_bspline_grid=False,
-    min_n4_iter=False,
+    adaptive_bspline_grid=False,
+    n4_iter=5,
     name="epi_reference_wf",
 ):
     """
@@ -86,12 +86,12 @@ def init_epi_reference_wf(
         If ``True``, determines nonsteady states in the beginning of the timeseries
         and selects them for the averaging of each run.
         IMPORTANT: this option applies only to BOLD EPIs.
-    use_bspline_grid : :obj:`bool`
+    adaptive_bspline_grid : :obj:`bool`
         If ``True``, determines the number of b-spline grid elements from data shape
         and feeds them into N4BiasFieldCorrection, rather than setting an isotropic distance.
-    min_n4_iter : :obj:`bool`
-        If ``True``, reduces the number of b-spline iterations from 5 to 4. This use-case
-        is intended for rodents and other non-human/non-adult cases.
+    n4_iter : :obj:`int`
+        The number of b-spline iterations (default: 5). Fewer (e.g. 4) are recommended
+        for rodents and other non-human/non-adult cases.
 
     Inputs
     ------
@@ -234,8 +234,8 @@ def init_epi_reference_wf(
         wf.connect(inputnode, "t_masks", per_run_avgs, "t_mask")
 
     # rodent-specific N4 settings
-    n4_avgs.inputs.n_iterations = [50] * (5 - min_n4_iter)
-    if use_bspline_grid:
+    n4_avgs.inputs.n_iterations = [50] * n4_iter
+    if adaptive_bspline_grid:
         from ...utils.images import _bspline_grid
         # set INU bspline grid based on voxel size
         bspline_grid = pe.Node(niu.Function(function=_bspline_grid), name="bspline_grid")

--- a/niworkflows/workflows/epi/refmap.py
+++ b/niworkflows/workflows/epi/refmap.py
@@ -237,12 +237,13 @@ def init_epi_reference_wf(
     n4_avgs.inputs.n_iterations = [50] * n4_iter
     if adaptive_bspline_grid:
         from ...utils.images import _bspline_grid
+        from ...utils.connections import pop_file as _pop
         # set INU bspline grid based on voxel size
         bspline_grid = pe.Node(niu.Function(function=_bspline_grid), name="bspline_grid")
 
         # fmt:off
         wf.connect([
-            (validate_nii, bspline_grid, [("out_file", "in_file")]),
+            (clip_avgs, bspline_grid, [(("out_file", _pop), "in_file")]),
             (bspline_grid, n4_avgs, [("out", "args")])
         ])
         # fmt:on

--- a/niworkflows/workflows/epi/refmap.py
+++ b/niworkflows/workflows/epi/refmap.py
@@ -166,6 +166,7 @@ def init_epi_reference_wf(
         N4BiasFieldCorrection(
             dimension=3,
             copy_header=True,
+            n_iterations=[50]*n4_iter,
             convergence_threshold=1e-7,
             shrink_factor=4,
         ),
@@ -234,7 +235,6 @@ def init_epi_reference_wf(
         wf.connect(inputnode, "t_masks", per_run_avgs, "t_mask")
 
     # rodent-specific N4 settings
-    n4_avgs.inputs.n_iterations = [50] * n4_iter
     if adaptive_bspline_grid:
         from ...utils.images import _bspline_grid
         from ...utils.connections import pop_file as _pop

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     matplotlib >= 2.2.0
     nibabel >= 3.0.1
     nilearn >= 0.2.6, != 0.5.0, != 0.5.1
-    nipype >= 1.5.1
+    nipype @ git+https://github.com/nipy/nipype.git@master
     nitransforms >= 20.0.0rc3,<20.2
     numpy
     packaging


### PR DESCRIPTION
Addressing #611, this PR 1) adds a function to determine bspline grid using a ratio of the number of slices in each dimension, and 2) adds logic to various workflows so that this might be used with rodents by updating the N4 parameters.  Not to say that the function can't be used with non-rodent images, but it hasn't been tested as such. 

There are other workflows that call `N4BiasFieldCorrection`, but they are unlikely to be used by NiRodents/fprodents because there are already rodent alternatives or because they would require more changes and would probably benefit from a rodent-specific workflow. 