### PR TITLE
FIX: DerivativesDataSink warning when it has multiple source files [backport #573]

### DIFF
--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -2,7 +2,6 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Interfaces for handling BIDS-like neuroimaging structures."""
 from collections import defaultdict
-from collections.abc import Sequence
 from json import dumps, loads
 from pathlib import Path
 from shutil import copytree, rmtree

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -616,7 +616,7 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
 
                 if data_dtype == "source":  # match source dtype
                     try:
-                        data_dtype = self.inputs.source_file[0].get_data_dtype()
+                        data_dtype = nb.load(self.inputs.source_file[0]).get_data_dtype()
                     except Exception:
                         LOGGER.warning(
                             f"Could not get data type of file {self.inputs.source_file[0]}"

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -620,7 +620,7 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
                         data_dtype = self.inputs.source_file[0].get_data_dtype()
                     except Exception:
                         LOGGER.warning(
-                            f"Could not get data type of file {self.inputs.source_file}"
+                            f"Could not get data type of file {self.inputs.source_file[0]}"
                         )
                         data_dtype = None
 

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -2,6 +2,7 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Interfaces for handling BIDS-like neuroimaging structures."""
 from collections import defaultdict
+from collections.abc import Sequence
 from json import dumps, loads
 from pathlib import Path
 from shutil import copytree, rmtree
@@ -616,7 +617,10 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
 
                 if data_dtype == "source":  # match source dtype
                     try:
-                        data_dtype = nb.load(self.inputs.source_file).get_data_dtype()
+                        source_file = self.inputs.source_file
+                        if isinstance(source_file, Sequence) and not isinstance(source_file, str):
+                            source_file = source_file[0]
+                        data_dtype = nb.load(source_file).get_data_dtype()
                     except Exception:
                         LOGGER.warning(
                             f"Could not get data type of file {self.inputs.source_file}"

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -617,10 +617,7 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
 
                 if data_dtype == "source":  # match source dtype
                     try:
-                        source_file = self.inputs.source_file
-                        if isinstance(source_file, Sequence) and not isinstance(source_file, str):
-                            source_file = source_file[0]
-                        data_dtype = nb.load(source_file).get_data_dtype()
+                        data_dtype = self.inputs.source_file[0].get_data_dtype()
                     except Exception:
                         LOGGER.warning(
                             f"Could not get data type of file {self.inputs.source_file}"

--- a/niworkflows/interfaces/tests/test_bids.py
+++ b/niworkflows/interfaces/tests/test_bids.py
@@ -521,11 +521,7 @@ def test_DerivativesDataSink_data_dtype_source(
 
         size = (30, 30, 30, 10)
 
-        hdr = nb.Nifti1Header()
-        hdr.set_qform(np.eye(4), code=0)
-        hdr.set_sform(np.eye(4), code=2)
-        hdr.set_data_dtype(dtype)
-        nb.Nifti1Image(np.zeros(size, dtype=dtype), np.eye(4), hdr).to_filename(fname)
+        nb.Nifti1Image(np.zeros(size, dtype=dtype), np.eye(4)).to_filename(fname)
 
     in_file = str(tmp_path / "in.nii")
     make_empty_nii_with_dtype(in_file, in_dtype)

--- a/niworkflows/interfaces/tests/test_bids.py
+++ b/niworkflows/interfaces/tests/test_bids.py
@@ -516,14 +516,16 @@ def test_DerivativesDataSink_data_dtype_source(
     tmp_path, source_file, source_dtype, in_dtype
 ):
 
-    def make_empty_nii_with_dtype(path, dtype):
+    def make_empty_nii_with_dtype(fname, dtype):
+        Path(fname).parent.mkdir(exist_ok=True, parents=True)
+
         size = (30, 30, 30, 10)
 
         hdr = nb.Nifti1Header()
         hdr.set_qform(np.eye(4), code=0)
         hdr.set_sform(np.eye(4), code=2)
         hdr.set_data_dtype(dtype)
-        nb.Nifti1Image(np.zeros(size, dtype=dtype), np.eye(4), hdr).to_filename(in_file)
+        nb.Nifti1Image(np.zeros(size, dtype=dtype), np.eye(4), hdr).to_filename(fname)
 
     in_file = str(tmp_path / "in.nii")
     make_empty_nii_with_dtype(in_file, in_dtype)

--- a/niworkflows/interfaces/tests/test_bids.py
+++ b/niworkflows/interfaces/tests/test_bids.py
@@ -519,7 +519,7 @@ def test_DerivativesDataSink_data_dtype_source(
     def make_empty_nii_with_dtype(fname, dtype):
         Path(fname).parent.mkdir(exist_ok=True, parents=True)
 
-        size = (30, 30, 30, 10)
+        size = (2, 3, 4, 5)
 
         nb.Nifti1Image(np.zeros(size, dtype=dtype), np.eye(4)).to_filename(fname)
 


### PR DESCRIPTION
As per https://github.com/nipreps/niworkflows/pull/573#issuecomment-893510319