### PR TITLE
ENH: Allow plotting of image rotated to cardinal axes

### DIFF
--- a/niworkflows/interfaces/reportlets/base.py
+++ b/niworkflows/interfaces/reportlets/base.py
@@ -52,6 +52,7 @@ class RegistrationRC(reporting.ReportCapableInterface):
     _fixed_image_label = "fixed"
     _moving_image_label = "moving"
     _contour = None
+    _dismiss_affine = False
 
     def _generate_report(self):
         """Generate the visual report."""
@@ -96,6 +97,7 @@ class RegistrationRC(reporting.ReportCapableInterface):
                 label=self._fixed_image_label,
                 contour=contour_nii,
                 compress=self.inputs.compress_report,
+                dismiss_affine=self._dismiss_affine,
             ),
             plot_registration(
                 moving_image_nii,
@@ -105,6 +107,7 @@ class RegistrationRC(reporting.ReportCapableInterface):
                 label=self._moving_image_label,
                 contour=contour_nii,
                 compress=self.inputs.compress_report,
+                dismiss_affine=self._dismiss_affine,
             ),
             out_file=self._out_report,
         )

--- a/niworkflows/interfaces/reportlets/registration.py
+++ b/niworkflows/interfaces/reportlets/registration.py
@@ -351,6 +351,9 @@ class _SimpleBeforeAfterInputSpecRPT(nrb._SVGReportCapableInputSpec):
     wm_seg = File(desc="reference white matter segmentation mask")
     before_label = traits.Str("before", usedefault=True)
     after_label = traits.Str("after", usedefault=True)
+    dismiss_affine = traits.Bool(
+        False, usedefault=True, desc="rotate image(s) to cardinal axes"
+    )
 
 
 class SimpleBeforeAfterRPT(nrb.RegistrationRC, nrb.ReportingInterface):
@@ -363,6 +366,7 @@ class SimpleBeforeAfterRPT(nrb.RegistrationRC, nrb.ReportingInterface):
         self._fixed_image = self.inputs.after
         self._moving_image = self.inputs.before
         self._contour = self.inputs.wm_seg if isdefined(self.inputs.wm_seg) else None
+        self._dismiss_affine = self.inputs.dismiss_affine
         NIWORKFLOWS_LOG.info(
             "Report - setting before (%s) and after (%s) images",
             self._fixed_image,

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -324,6 +324,7 @@ def plot_registration(
     label=None,
     contour=None,
     compress="auto",
+    dismiss_affine=False,
 ):
     """
     Plots the foreground and background views
@@ -350,6 +351,15 @@ def plot_registration(
         contour_data = contour.get_fdata() % 39
         white = nlimage.new_img_like(contour, contour_data == 2)
         pial = nlimage.new_img_like(contour, contour_data >= 2)
+
+    if dismiss_affine:
+        canonical_r = rotation2canonical(anat_nii)
+        anat_nii = rotate_affine(anat_nii, rot=canonical_r)
+        if ribbon:
+            white = rotate_affine(white, rot=canonical_r)
+            pial = rotate_affine(pial, rot=canonical_r)
+        if contour:
+            contour = rotate_affine(contour, rot=canonical_r)
 
     # Plot each cut axis
     for i, mode in enumerate(list(order)):


### PR DESCRIPTION
Follows #544 

Allows `SimpleBeforeAfter` reports to rotate images with respect to the cardinal axes. This is motivated in the context of SDC correction, to give a clearer look at the distortions.

<img width="1231" alt="Screen Shot 2021-08-31 at 3 43 06 PM" src="https://user-images.githubusercontent.com/14110164/131565952-592de91a-fad8-48b9-a73e-b99faad7e910.png">
<img width="1234" alt="Screen Shot 2021-08-31 at 3 43 15 PM" src="https://user-images.githubusercontent.com/14110164/131565966-da9e0642-6e7e-41e3-9b37-a2def864885d.png">
