### PR TITLE
ENH: Initiate a module of nipype interfaces for mathematical morphology

### DIFF
--- a/niworkflows/interfaces/morphology.py
+++ b/niworkflows/interfaces/morphology.py
@@ -88,7 +88,7 @@ class BinarySubtraction(SimpleInterface):
         data = np.bool_(base_img.dataobj)
         data[np.bool_(nb.load(self.inputs.in_subtract).dataobj)] = False
 
-        out_file = str((Path(runtime.cwd) / "dilated_mask.nii.gz").absolute())
+        out_file = str((Path(runtime.cwd) / "subtracted_mask.nii.gz").absolute())
         out_img = base_img.__class__(
             data,
             base_img.affine,

--- a/niworkflows/interfaces/morphology.py
+++ b/niworkflows/interfaces/morphology.py
@@ -77,7 +77,7 @@ class _BinarySubtractionOutputSpec(TraitedSpec):
 
 
 class BinarySubtraction(SimpleInterface):
-    """Binary dilation of a mask."""
+    """Binary subtraction of two masks."""
 
     input_spec = _BinarySubtractInputSpec
     output_spec = _BinarySubtractionOutputSpec

--- a/niworkflows/interfaces/morphology.py
+++ b/niworkflows/interfaces/morphology.py
@@ -61,9 +61,7 @@ class BinaryDilation(SimpleInterface):
             radius=self.inputs.radius,
         )
         out_file = str((Path(runtime.cwd) / "dilated_mask.nii.gz").absolute())
-        out_img = mask_img.__class__(
-            dilated, mask_img.affine, mask_img.header
-        )
+        out_img = mask_img.__class__(dilated, mask_img.affine, mask_img.header)
         out_img.set_data_dtype("uint8")
         out_img.to_filename(out_file)
         self._results["out_mask"] = out_file
@@ -73,7 +71,7 @@ class BinaryDilation(SimpleInterface):
 def image_binary_dilation(in_mask, radius=2):
     """
     Dilate the input binary mask.
-    
+
     Parameters
     ----------
     in_mask: :obj:`numpy.ndarray`

--- a/niworkflows/interfaces/morphology.py
+++ b/niworkflows/interfaces/morphology.py
@@ -1,0 +1,105 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright 2021 The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+""" Handling brain mask"""
+
+from nipype.interfaces.base import (
+    traits,
+    TraitedSpec,
+    BaseInterfaceInputSpec,
+    File,
+    SimpleInterface,
+)
+
+
+class _CrownMaskInputSpec(BaseInterfaceInputSpec):
+    in_segm = File(
+        exists=True, mandatory=True, position=0, desc="Input discrete segmentation of the brain."
+    )
+    in_brainmask = File(exists=True, mandatory=True, position=1, desc="Brain mask.")
+    radius = traits.Int(default_value=2, usedefault=True, desc="Radius of dilation")
+
+
+class _CrownMaskOutputSpec(TraitedSpec):
+    out_mask = File(exists=False, desc="Crown mask")
+
+
+class CrownMask(SimpleInterface):
+    """Dilate brain mask for computing the crown mask."""
+
+    input_spec = _CrownMaskInputSpec
+    output_spec = _CrownMaskOutputSpec
+
+    def _run_interface(self, runtime):
+        import nibabel as nb
+        import numpy as np
+        from pathlib import Path
+
+        # Open files
+        segm_img = nb.load(self.inputs.in_segm)
+        brainmask_img = nb.load(self.inputs.in_brainmask)
+
+        segm = np.bool_(segm_img.dataobj)
+        brainmask = np.bool_(brainmask_img.dataobj)
+
+        # Obtain dilated brainmask
+        crown_mask, func_seg_mask = get_dilated_brainmask(
+            seg_mask=segm,
+            brainmask=brainmask,
+            radius=self.inputs.radius,
+        )
+        # Remove the brain from the crown mask
+        crown_mask[func_seg_mask] = False
+        crown_file = str((Path(runtime.cwd) / "crown_mask.nii.gz").absolute())
+        nii = nb.Nifti1Image(
+            crown_mask, brainmask_img.affine, brainmask_img.header
+        )
+        nii.set_data_dtype("uint8")
+        nii.to_filename(crown_file)
+        self._results["out_mask"] = crown_file
+
+        return runtime
+
+
+def get_dilated_brainmask(seg_mask, brainmask, radius=2):
+    """Obtain the brain mask dilated
+    Parameters
+    ----------
+    atlaslabels: ndarray
+        A 3D binary array, resampled into ``img`` space.
+    brainmask: ndarray
+        A 3D binary array, resampled into ``img`` space.
+    radius: int, optional
+        The radius of the ball-shaped footprint for dilation of the mask.
+    """
+    from scipy import ndimage as ndi
+    from skimage.morphology import ball
+
+    # Union of functionally and anatomically extracted masks
+    func_seg_mask = seg_mask | brainmask
+
+    if func_seg_mask.ndim != 3:
+        raise Exception("The brain mask should be a 3D array")
+
+    dilated_brainmask = ndi.binary_dilation(func_seg_mask, ball(radius))
+
+    return dilated_brainmask, func_seg_mask

--- a/niworkflows/interfaces/morphology.py
+++ b/niworkflows/interfaces/morphology.py
@@ -37,11 +37,11 @@ class _BinaryDilationInputSpec(BaseInterfaceInputSpec):
 
 
 class _BinaryDilationOutputSpec(TraitedSpec):
-    out_mask = File(exists=False, desc="Crown mask")
+    out_mask = File(exists=False, desc="dilated mask")
 
 
 class BinaryDilation(SimpleInterface):
-    """Dilate brain mask for computing the crown mask."""
+    """Binary dilation of a mask."""
 
     input_spec = _BinaryDilationInputSpec
     output_spec = _BinaryDilationOutputSpec

--- a/niworkflows/interfaces/morphology.py
+++ b/niworkflows/interfaces/morphology.py
@@ -1,7 +1,7 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 #
-# Copyright 2021 The NiPreps Developers <nipreps@gmail.com>
+# Copyright 2022 The NiPreps Developers <nipreps@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 #
 #     https://www.nipreps.org/community/licensing/
 #
-""" Handling brain mask"""
+"""Mathematical morphology operations as nipype interfaces."""
 
 from nipype.interfaces.base import (
     traits,
@@ -31,23 +31,20 @@ from nipype.interfaces.base import (
 )
 
 
-class _CrownMaskInputSpec(BaseInterfaceInputSpec):
-    in_segm = File(
-        exists=True, mandatory=True, position=0, desc="Input discrete segmentation of the brain."
-    )
-    in_brainmask = File(exists=True, mandatory=True, position=1, desc="Brain mask.")
-    radius = traits.Int(default_value=2, usedefault=True, desc="Radius of dilation")
+class _BinaryDilationInputSpec(BaseInterfaceInputSpec):
+    in_mask = File(exists=True, mandatory=True, position=1, desc="input mask")
+    radius = traits.Int(2, usedefault=True, desc="Radius of dilation")
 
 
-class _CrownMaskOutputSpec(TraitedSpec):
+class _BinaryDilationOutputSpec(TraitedSpec):
     out_mask = File(exists=False, desc="Crown mask")
 
 
-class CrownMask(SimpleInterface):
+class BinaryDilation(SimpleInterface):
     """Dilate brain mask for computing the crown mask."""
 
-    input_spec = _CrownMaskInputSpec
-    output_spec = _CrownMaskOutputSpec
+    input_spec = _BinaryDilationInputSpec
+    output_spec = _BinaryDilationOutputSpec
 
     def _run_interface(self, runtime):
         import nibabel as nb
@@ -55,51 +52,36 @@ class CrownMask(SimpleInterface):
         from pathlib import Path
 
         # Open files
-        segm_img = nb.load(self.inputs.in_segm)
-        brainmask_img = nb.load(self.inputs.in_brainmask)
-
-        segm = np.bool_(segm_img.dataobj)
-        brainmask = np.bool_(brainmask_img.dataobj)
+        mask_img = nb.load(self.inputs.in_mask)
+        maskdata = np.bool_(mask_img.dataobj)
 
         # Obtain dilated brainmask
-        crown_mask, func_seg_mask = get_dilated_brainmask(
-            seg_mask=segm,
-            brainmask=brainmask,
+        dilated = image_binary_dilation(
+            maskdata,
             radius=self.inputs.radius,
         )
-        # Remove the brain from the crown mask
-        crown_mask[func_seg_mask] = False
-        crown_file = str((Path(runtime.cwd) / "crown_mask.nii.gz").absolute())
-        nii = nb.Nifti1Image(
-            crown_mask, brainmask_img.affine, brainmask_img.header
+        out_file = str((Path(runtime.cwd) / "dilated_mask.nii.gz").absolute())
+        out_img = mask_img.__class__(
+            dilated, mask_img.affine, mask_img.header
         )
-        nii.set_data_dtype("uint8")
-        nii.to_filename(crown_file)
-        self._results["out_mask"] = crown_file
-
+        out_img.set_data_dtype("uint8")
+        out_img.to_filename(out_file)
+        self._results["out_mask"] = out_file
         return runtime
 
 
-def get_dilated_brainmask(seg_mask, brainmask, radius=2):
-    """Obtain the brain mask dilated
+def image_binary_dilation(in_mask, radius=2):
+    """
+    Dilate the input binary mask.
+    
     Parameters
     ----------
-    atlaslabels: ndarray
-        A 3D binary array, resampled into ``img`` space.
-    brainmask: ndarray
-        A 3D binary array, resampled into ``img`` space.
-    radius: int, optional
+    in_mask: :obj:`numpy.ndarray`
+        A 3D binary array.
+    radius: :obj:`int`, optional
         The radius of the ball-shaped footprint for dilation of the mask.
     """
     from scipy import ndimage as ndi
     from skimage.morphology import ball
 
-    # Union of functionally and anatomically extracted masks
-    func_seg_mask = seg_mask | brainmask
-
-    if func_seg_mask.ndim != 3:
-        raise Exception("The brain mask should be a 3D array")
-
-    dilated_brainmask = ndi.binary_dilation(func_seg_mask, ball(radius))
-
-    return dilated_brainmask, func_seg_mask
+    return ndi.binary_dilation(in_mask.astype(bool), ball(radius)).astype(int)

--- a/niworkflows/interfaces/plotting.py
+++ b/niworkflows/interfaces/plotting.py
@@ -37,7 +37,7 @@ from ..viz.plots import fMRIPlot, compcor_variance_plot, confounds_correlation_p
 
 class _FMRISummaryInputSpec(BaseInterfaceInputSpec):
     in_func = File(exists=True, mandatory=True, desc="")
-    in_mask = File(exists=True, desc="")
+    in_crown = File(exists=True, desc="")
     in_segm = File(exists=True, desc="")
     in_spikes_bg = File(exists=True, mandatory=True, desc="")
     fd = File(exists=True, mandatory=True, desc="")
@@ -82,7 +82,7 @@ class FMRISummary(SimpleInterface):
 
         fig = fMRIPlot(
             self.inputs.in_func,
-            mask_file=self.inputs.in_mask if isdefined(self.inputs.in_mask) else None,
+            crown_file=self.inputs.in_crown if isdefined(self.inputs.in_crown) else None,
             seg_file=self.inputs.in_segm if isdefined(self.inputs.in_segm) else None,
             spikes_files=[self.inputs.in_spikes_bg],
             tr=self.inputs.tr,

--- a/niworkflows/interfaces/plotting.py
+++ b/niworkflows/interfaces/plotting.py
@@ -37,7 +37,7 @@ from ..viz.plots import fMRIPlot, compcor_variance_plot, confounds_correlation_p
 
 class _FMRISummaryInputSpec(BaseInterfaceInputSpec):
     in_func = File(exists=True, mandatory=True, desc="")
-    in_crown = File(exists=True, desc="")
+    in_mask = File(exists=True, desc="")
     in_segm = File(exists=True, desc="")
     in_spikes_bg = File(exists=True, mandatory=True, desc="")
     fd = File(exists=True, mandatory=True, desc="")
@@ -82,7 +82,7 @@ class FMRISummary(SimpleInterface):
 
         fig = fMRIPlot(
             self.inputs.in_func,
-            crown_file=self.inputs.in_crown if isdefined(self.inputs.in_crown) else None,
+            mask_file=self.inputs.in_mask if isdefined(self.inputs.in_mask) else None,
             seg_file=self.inputs.in_segm if isdefined(self.inputs.in_segm) else None,
             spikes_files=[self.inputs.in_spikes_bg],
             tr=self.inputs.tr,

--- a/niworkflows/interfaces/tests/test_morphology.py
+++ b/niworkflows/interfaces/tests/test_morphology.py
@@ -1,0 +1,74 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright 2022 The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+"""Test morphology module."""
+from pathlib import Path
+import shutil
+import numpy as np
+import nibabel as nb
+
+from niworkflows.interfaces.morphology import (
+    BinaryDilation,
+    BinarySubtraction,
+)
+
+
+def test_BinaryDilation_interface(tmpdir):
+    """Check the dilation interface."""
+
+    data = np.zeros((80, 80, 80), dtype="uint8")
+    data[30:-30, 35:-35, 20:-20] = 1
+
+    nb.Nifti1Image(data, np.eye(4), None).to_filename("mask.nii.gz")
+
+    out1 = (
+        BinaryDilation(
+            in_mask=str(Path("mask.nii.gz").absolute()),
+            radius=4,
+        )
+        .run()
+        .outputs.out_mask
+    )
+    shutil.move(out1, "large_radius.nii.gz")
+
+    out2 = (
+        BinaryDilation(
+            in_mask=str(Path("mask.nii.gz").absolute()),
+            radius=1,
+        )
+        .run()
+        .outputs.out_mask
+    )
+    shutil.move(out2, "small_radius.nii.gz")
+
+    out_final = (
+        BinarySubtraction(
+            in_base=str(Path("large_radius.nii.gz").absolute()),
+            in_subtract=str(Path("small_radius.nii.gz").absolute()),
+        )
+        .run()
+        .outputs.out_mask
+    )
+
+    out_data = np.asanyarray(nb.load(out_final).dataobj, dtype="uint8")
+
+    assert np.all(out_data[data] == 0)


### PR DESCRIPTION
This pull request augments the existing carpet plot by adding to it the signals from the voxels at the edge of the brain.
The new code contains both the computation of the crown mask and its insertion in the carpet plot.

Furthermore, an interface computing the crown mask has been added in the purpose of being used in fMRIPrep and MRIQC.

Last, a legend of the colorbar separating regions in the carpet plot has been adding therefore closing nipreps/mriqc#870.

IMPORTANT ! : This piece of code depends on the change in the fMRIprep repository commited under the pull request https://github.com/nipreps/fmriprep/pull/2621 and on the change in the MRIQC repository under the pull request nipreps/mriqc#968