### PR TITLE
REL: 1.3.5

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -74,6 +74,18 @@
       "name": "Thompson, William H.",
       "orcid": "0000-0002-0533-6035",
       "type": "Researcher"
+    },
+    {
+      "affiliation": "Charite Universitatsmedizin Berlin, Germany",
+      "name": "Waller, Lea",
+      "orcid": "0000-0002-3239-6957",
+      "type": "Researcher"
+    },
+    {
+      "affiliation": "University of Zurich, Switzerland",
+      "name": "de Hollander, Gilles",
+      "orcid": "0000-0003-1988-5091",
+      "type": "Researcher"
     }
   ],
   "keywords": [

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+1.3.5 (October 01, 2021)
+========================
+Bug-fix release in the 1.3.x series
+
+  * FIX: Set slope and intercept to 1/0 if not otherwise provided (#649)
+  * FIX: DerivativesDataSink warning when it has multiple source files [backport #573] (#647)
+  * FIX: `FSDetectInputs` mutually exclusive options for `ReconAll` (#646)
+  * MNT: Update some version pinning and correct for *pandas* warning about keyword arguments (#645)
+  * CI: Use datalad-managed test data [BACKPORT] (#653)
+
 1.3.4 (June 8, 2021)
 ====================
 Bug-fix release in the 1.3.x series.

--- a/tools/update_changes.sh
+++ b/tools/update_changes.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Collects the pull-requests since the latest release and
+# aranges them in the CHANGES.rst.txt file.
+#
+# This is a script to be run before releasing a new version.
+#
+# Usage /bin/bash update_changes.sh 1.0.1
+#
+
+# Setting      # $ help set
+set -u         # Treat unset variables as an error when substituting.
+set -x         # Print command traces before executing command.
+
+# Check whether the Upcoming release header is present
+head -1 CHANGES.rst | grep -q Upcoming
+UPCOMING=$?
+if [[ "$UPCOMING" == "0" ]]; then
+    head -n3  CHANGES.rst >> newchanges
+fi
+
+# Elaborate today's release header
+HEADER="$1 ($(date '+%B %d, %Y'))"
+echo $HEADER >> newchanges
+echo $( printf "%${#HEADER}s" | tr " " "=" ) >> newchanges
+echo "" >> newchanges
+
+# Search for PRs since previous release
+git log --grep="Merge pull request" `git describe --tags --abbrev=0`..HEAD --pretty='format:  * %b %s' | sed  's/Merge pull request \#\([^\d]*\)\ from\ .*/(\#\1)/' >> newchanges
+echo "" >> newchanges
+echo "" >> newchanges
+
+# Add back the Upcoming header if it was present
+if [[ "$UPCOMING" == "0" ]]; then
+    tail -n+4 CHANGES.rst >> newchanges
+else
+    cat CHANGES.rst >> newchanges
+fi
+
+# Replace old CHANGES.rst with new file
+mv newchanges CHANGES.rst
+


### PR DESCRIPTION
Needed for a 20.2.4 release of fMRIPrep.

Added @HippocampusGirl and @Gilles86 to Zenodo for their contributions, though I think Gilles's contribution was a bit ago...