### PR TITLE
DOC: Ensure commits to master trigger a documentation update

### DIFF
--- a/.github/workflows/docs-build-update.yml
+++ b/.github/workflows/docs-build-update.yml
@@ -49,7 +49,7 @@ jobs:
           make -C docs/ SPHINXOPTS="-W" BUILDDIR="$HOME/docs" OUTDIR="${CURBRANCH:-html}" html
 
     - name: Push created tag to gh-pages
-      if: startsWith(github.ref, 'refs/tags/')
+      if: github.ref == 'refs/heads/master')
       run: |
         MAJOR_MINOR=${CURBRANCH%.*}
         if [[ "${MAJOR_MINOR}" == "" ]]; then


### PR DESCRIPTION
Fixes a bad condition that averted the push of the new docs (#656)