### PR TITLE
ENH: Avoid appending packagename to `Report` outputs

### DIFF
--- a/niworkflows/reports/core.py
+++ b/niworkflows/reports/core.py
@@ -245,13 +245,13 @@ class Report:
     .. doctest::
 
     >>> robj = Report(testdir / 'out', 'madeoutuuid', subject_id='01', packagename='fmriprep',
-    ...               reportlets_dir=testdir / 'work' / 'reportlets')
+    ...               reportlets_dir=testdir / 'work' / 'reportlets' / 'fmriprep')
     >>> robj.layout.get(subject='01', desc='reconall')  # doctest: +ELLIPSIS
     [<BIDSFile filename='.../figures/sub-01_desc-reconall_T1w.svg'>]
 
     >>> robj.generate_report()
     0
-    >>> len((testdir / 'out' / 'fmriprep' / 'sub-01.html').read_text())
+    >>> len((testdir / 'out' / 'sub-01.html').read_text())
     36693
 
     .. testcleanup::
@@ -512,7 +512,7 @@ def run_reports(
     .. doctest::
 
     >>> run_reports(testdir / 'out', '01', 'madeoutuuid', packagename='fmriprep',
-    ...             reportlets_dir=testdir / 'work' / 'reportlets')
+    ...             reportlets_dir=testdir / 'work' / 'reportlets'/ 'fmriprep')
     0
 
     .. testcleanup::

--- a/niworkflows/reports/core.py
+++ b/niworkflows/reports/core.py
@@ -297,10 +297,6 @@ class Report:
         settings = load(config.read_text())
         self.packagename = self.packagename or settings.get("package", None)
 
-        if self.packagename is not None:
-            self.root = self.root / self.packagename
-            self.out_dir = self.out_dir / self.packagename
-
         if self.subject_id is not None:
             self.root = self.root / "sub-{}".format(self.subject_id)
 

--- a/niworkflows/reports/tests/test_core.py
+++ b/niworkflows/reports/tests/test_core.py
@@ -229,9 +229,9 @@ def test_generated_reportlets(bids_sessions, ordering):
     # make independent report
     out_dir = tempfile.mkdtemp()
     report = Report(
-        Path(out_dir),
+        Path(out_dir) / "fmriprep",
         "fakeuuid",
-        reportlets_dir=Path(bids_sessions),
+        reportlets_dir=Path(bids_sessions) / "fmriprep",
         subject_id="01",
         packagename="fmriprep",
     )

--- a/niworkflows/reports/tests/test_core.py
+++ b/niworkflows/reports/tests/test_core.py
@@ -112,7 +112,7 @@ def test_report1():
     return Report(
         Path(out_dir),
         "fakeuuid",
-        reportlets_dir=Path(test_data_path),
+        reportlets_dir=Path(test_data_path) / 'fmriprep',
         subject_id="01",
         packagename="fmriprep",
     )
@@ -124,7 +124,7 @@ def test_report2(bids_sessions):
     return Report(
         Path(out_dir),
         "fakeuuid",
-        reportlets_dir=Path(bids_sessions),
+        reportlets_dir=Path(bids_sessions) / 'fmriprep',
         subject_id="01",
         packagename="fmriprep",
     )
@@ -267,10 +267,9 @@ def test_generated_reportlets(bids_sessions, ordering):
     ],
 )
 def test_subject_id(tmp_path, subject_id, out_html):
-    reports = tmp_path / "reports"
+    reports = tmp_path / "reports" / "fmriprep"
     Path(
         reports
-        / "fmriprep"
         / (subject_id if subject_id.startswith("sub-") else f"sub-{subject_id}")
     ).mkdir(parents=True)
 


### PR DESCRIPTION
Now that YODA is the default in `fmriprep`/`nibabies`, lets remove the hacks:

https://github.com/nipreps/fmriprep/blob/4795349af994e3fa62331c1f6e89d7e8b829ba04/fmriprep/reports/core.py#L26-L47
https://github.com/nipreps/nibabies/blob/55143215eaebca4924cefdc74d8008a347efea16/nibabies/reports/core.py#L5-L22
