### PR TITLE
MNT: Configure black to avoid excessive rewriting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
 [build-system]
 # Keep synchronized with the minimum version to install in setup.py
 requires = ["setuptools >= 38.4.1", "wheel"]
+
+[tool.black]
+line-length = 99
+target-version = ['py37']
+skip-string-normalization = true
+extend-exclude = '_version.py|versioneer.py'


### PR DESCRIPTION
Any objection to these configurations? By using a higher line length and not changing all quotes to double-quote, we can keep the sheer amount of rewrites down.

Would like to bring this over to fMRIPrep and the other tools, too.