### PR TITLE
MNT: Relax matplotlib constraint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ python_requires = >= 3.7
 install_requires =
     attrs
     jinja2
-    matplotlib ~= 3.3.1
+    matplotlib ~= 3.3, >= 3.3.1
     nibabel ~= 3.0
     nilearn >= 0.5.2
     nipype ~= 1.5


### PR DESCRIPTION
This still ensures we don't get 3.3.0, but allows us to go gracefully up minor version releases of MPL.

Closes #667,