### PR TITLE
TEST: Drop excessively long interface equivalence tests

### DIFF
--- a/niworkflows/interfaces/tests/test_images.py
+++ b/niworkflows/interfaces/tests/test_images.py
@@ -34,12 +34,7 @@ from .. import images as im
 @pytest.mark.parametrize(
     "nvols, nmasks, ext, factor",
     [
-        (500, 10, ".nii", 2),
-        (500, 10, ".nii.gz", 5),
         (200, 3, ".nii", 1.1),
-        (200, 3, ".nii.gz", 2),
-        (200, 10, ".nii", 1.1),
-        (200, 10, ".nii.gz", 2),
     ],
 )
 def test_signal_extraction_equivalence(tmp_path, nvols, nmasks, ext, factor):


### PR DESCRIPTION
We know that our method runs faster and uses less memory than nilearn's, so let's take the fastest one and just ensure that we don't lose equivalence.