### PR TITLE
FIX: Unlink destination files before saving derivative

### DIFF
--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -664,6 +664,7 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
                         new_header.set_data_dtype(data_dtype)
                 del nii
 
+            out_file.unlink(missing_ok=True)
             if new_data is new_header is None:
                 _copy_any(orig_file, str(out_file))
             else:
@@ -704,9 +705,11 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
                             legacy_metadata[key] = self._metadata.pop(key)
                     if legacy_metadata:
                         sidecar = out_file.parent / f"{_splitext(str(out_file))[0]}.json"
+                        sidecar.unlink(missing_ok=True)
                         sidecar.write_text(dumps(legacy_metadata, sort_keys=True, indent=2))
                 # The future: the extension is the first . and everything after
                 sidecar = out_file.parent / f"{out_file.name.split('.', 1)[0]}.json"
+                sidecar.unlink(missing_ok=True)
                 sidecar.write_text(dumps(self._metadata, sort_keys=True, indent=2))
                 self._results["out_meta"] = str(sidecar)
         return runtime


### PR DESCRIPTION
If you have write permissions in a directory but not on a file (main context: locked git-annex files), then you can get a situation where trying to write without first deleting will fail while deleting and rewriting will succeed.