### PR TITLE
ENH: Add a legend to carpet plots with more than one segment

### DIFF
--- a/niworkflows/tests/test_viz.py
+++ b/niworkflows/tests/test_viz.py
@@ -60,7 +60,7 @@ def test_carpetplot(tr, sorting):
         drop_trs=15,
     )
 
-    labels = ("Cortical GM", "Deep GM", "Cerebellar GM", "WM + brainstem", "CSF")
+    labels = ("Ctx GM", "Subctx GM", "WM+CSF", "Cereb.", "Edge")
     sizes = (200, 100, 50, 100, 50)
     total_size = np.sum(sizes)
     data = np.zeros((total_size, 300))


### PR DESCRIPTION
Instead of printing labels on the left, this PR adds a legend beneath the carpet chunks. Hopefully closing the very much-needed overhaul of carpet plots.