### PR TITLE
FIX: Test failures

### DIFF
--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -126,7 +126,7 @@ sub-01/func/ses-retest/sub-01_ses-retest_task-covertverbgeneration_bold.nii.gz''
 
     >>> bids_info = BIDSInfo(bids_dir=str(datadir / 'ds054'), bids_validate=False)
     >>> bids_info.inputs.in_file = '''\
-sub-01/func/ses-retest/sub-01_ses-retest_task-covertverbgeneration_rec-MB_acq-AP_run-1_bold.nii.gz'''
+sub-01/func/ses-retest/sub-01_ses-retest_task-covertverbgeneration_rec-MB_acq-AP_run-01_bold.nii.gz'''
     >>> res = bids_info.run()
     >>> res.outputs
     <BLANKLINE>
@@ -416,12 +416,12 @@ class DerivativesDataSink(SimpleInterface):
     >>> dsink.inputs.desc = 'preproc'
     >>> res = dsink.run()
     >>> res.outputs.out_file  # doctest: +ELLIPSIS
-    '.../niworkflows/sub-02/ses-noanat/func/sub-02_ses-noanat_task-rest_run-1_\
+    '.../niworkflows/sub-02/ses-noanat/func/sub-02_ses-noanat_task-rest_run-01_\
 desc-preproc_bold.nii'
 
     >>> bids_dir = tmpdir / 'bidsroot' / 'sub-02' / 'ses-noanat' / 'func'
     >>> bids_dir.mkdir(parents=True, exist_ok=True)
-    >>> tricky_source = bids_dir / 'sub-02_ses-noanat_task-rest_run-1_bold.nii.gz'
+    >>> tricky_source = bids_dir / 'sub-02_ses-noanat_task-rest_run-01_bold.nii.gz'
     >>> tricky_source.open('w').close()
     >>> dsink = DerivativesDataSink(base_directory=str(tmpdir), check_hdr=False)
     >>> dsink.inputs.in_file = str(tmpfile)
@@ -430,7 +430,7 @@ desc-preproc_bold.nii'
     >>> dsink.inputs.RepetitionTime = 0.75
     >>> res = dsink.run()
     >>> res.outputs.out_meta  # doctest: +ELLIPSIS
-    '.../niworkflows/sub-02/ses-noanat/func/sub-02_ses-noanat_task-rest_run-1_\
+    '.../niworkflows/sub-02/ses-noanat/func/sub-02_ses-noanat_task-rest_run-01_\
 desc-preproc_bold.json'
 
     >>> Path(res.outputs.out_meta).read_text().splitlines()[1]
@@ -450,7 +450,7 @@ desc-preproc_bold.json'
     >>> dsink.inputs.RepetitionTime = 0.75
     >>> res = dsink.run()
     >>> res.outputs.out_meta  # doctest: +ELLIPSIS
-    '.../niworkflows/sub-02/ses-noanat/func/sub-02_ses-noanat_task-rest_run-1_\
+    '.../niworkflows/sub-02/ses-noanat/func/sub-02_ses-noanat_task-rest_run-01_\
 space-MNI152NLin6Asym_res-01_desc-preproc_bold.json'
 
     >>> lines = Path(res.outputs.out_meta).read_text().splitlines()
@@ -475,7 +475,7 @@ space-MNI152NLin6Asym_res-01_desc-preproc_bold.json'
     >>> dsink.inputs.meta_dict = {'RepetitionTime': 1.75, 'SkullStripped': False, 'Z': 'val'}
     >>> res = dsink.run()
     >>> res.outputs.out_meta  # doctest: +ELLIPSIS
-    '.../niworkflows/sub-02/ses-noanat/func/sub-02_ses-noanat_task-rest_run-1_\
+    '.../niworkflows/sub-02/ses-noanat/func/sub-02_ses-noanat_task-rest_run-01_\
 space-MNI152NLin6Asym_desc-preproc_bold.json'
 
     >>> lines = Path(res.outputs.out_meta).read_text().splitlines()

--- a/niworkflows/interfaces/tests/test_bids.py
+++ b/niworkflows/interfaces/tests/test_bids.py
@@ -150,28 +150,28 @@ BOLD_PATH = "ds054/sub-100185/func/sub-100185_task-machinegame_run-01_bold.nii.g
             BOLD_PATH,
             ["aroma.csv"],
             {"suffix": "AROMAnoiseICs"},
-            "sub-100185/func/sub-100185_task-machinegame_run-1_AROMAnoiseICs.csv",
+            "sub-100185/func/sub-100185_task-machinegame_run-01_AROMAnoiseICs.csv",
             "da39a3ee5e6b4b0d3255bfef95601890afd80709",
         ),
         (
             BOLD_PATH,
             ["confounds.tsv"],
             {"suffix": "regressors", "desc": "confounds"},
-            "sub-100185/func/sub-100185_task-machinegame_run-1_desc-confounds_regressors.tsv",
+            "sub-100185/func/sub-100185_task-machinegame_run-01_desc-confounds_regressors.tsv",
             "da39a3ee5e6b4b0d3255bfef95601890afd80709",
         ),
         (
             BOLD_PATH,
             ["mixing.tsv"],
             {"suffix": "mixing", "desc": "MELODIC"},
-            "sub-100185/func/sub-100185_task-machinegame_run-1_desc-MELODIC_mixing.tsv",
+            "sub-100185/func/sub-100185_task-machinegame_run-01_desc-MELODIC_mixing.tsv",
             "da39a3ee5e6b4b0d3255bfef95601890afd80709",
         ),
         (
             BOLD_PATH,
             ["lh.func.gii"],
             {"space": "fsaverage", "density": "10k", "hemi": "L"},
-            "sub-100185/func/sub-100185_task-machinegame_run-1_"
+            "sub-100185/func/sub-100185_task-machinegame_run-01_"
             "hemi-L_space-fsaverage_den-10k_bold.func.gii",
             "da39a3ee5e6b4b0d3255bfef95601890afd80709",
         ),
@@ -179,7 +179,7 @@ BOLD_PATH = "ds054/sub-100185/func/sub-100185_task-machinegame_run-01_bold.nii.g
             BOLD_PATH,
             ["hcp.dtseries.nii"],
             {"space": "fsLR", "density": "91k"},
-            "sub-100185/func/sub-100185_task-machinegame_run-1_"
+            "sub-100185/func/sub-100185_task-machinegame_run-01_"
             "space-fsLR_den-91k_bold.dtseries.nii",
             "53d9b486d08fec5a952f68fcbcddb38a72818d4c",
         ),
@@ -187,28 +187,28 @@ BOLD_PATH = "ds054/sub-100185/func/sub-100185_task-machinegame_run-01_bold.nii.g
             BOLD_PATH,
             ["ref.nii"],
             {"space": "MNI", "suffix": "boldref"},
-            "sub-100185/func/sub-100185_task-machinegame_run-1_space-MNI_boldref.nii",
+            "sub-100185/func/sub-100185_task-machinegame_run-01_space-MNI_boldref.nii",
             "53d9b486d08fec5a952f68fcbcddb38a72818d4c",
         ),
         (
             BOLD_PATH,
             ["dseg.nii"],
             {"space": "MNI", "suffix": "dseg", "desc": "aseg"},
-            "sub-100185/func/sub-100185_task-machinegame_run-1_space-MNI_desc-aseg_dseg.nii",
+            "sub-100185/func/sub-100185_task-machinegame_run-01_space-MNI_desc-aseg_dseg.nii",
             "ddadc9be8224eebe0177a65bf87300f275e17e96",
         ),
         (
             BOLD_PATH,
             ["mask.nii"],
             {"space": "MNI", "suffix": "mask", "desc": "brain"},
-            "sub-100185/func/sub-100185_task-machinegame_run-1_space-MNI_desc-brain_mask.nii",
+            "sub-100185/func/sub-100185_task-machinegame_run-01_space-MNI_desc-brain_mask.nii",
             "f97a1877508139b42ea9fc476bdba367b001ab00",
         ),
         (
             BOLD_PATH,
             ["bold.nii"],
             {"space": "MNI", "desc": "preproc"},
-            "sub-100185/func/sub-100185_task-machinegame_run-1_space-MNI_desc-preproc_bold.nii",
+            "sub-100185/func/sub-100185_task-machinegame_run-01_space-MNI_desc-preproc_bold.nii",
             "aa1eed935e6a8dcca646b0c78ee57218e30e2974",
         ),
         # Nondeterministic order - do we really need this to work, or we can stay safe with
@@ -246,10 +246,10 @@ BOLD_PATH = "ds054/sub-100185/func/sub-100185_task-machinegame_run-01_bold.nii.g
             "da39a3ee5e6b4b0d3255bfef95601890afd80709",
         ),
         (
-            "sub-07/ses-preop/anat/sub-07_ses-preop_run-1_T1w.nii.gz",
+            "sub-07/ses-preop/anat/sub-07_ses-preop_run-01_T1w.nii.gz",
             ["tfm.txt"],
             {"from": "orig", "to": "T1w", "suffix": "xfm"},
-            "sub-07/ses-preop/anat/sub-07_ses-preop_run-1_from-orig_to-T1w_mode-image_xfm.txt",
+            "sub-07/ses-preop/anat/sub-07_ses-preop_run-01_from-orig_to-T1w_mode-image_xfm.txt",
             "da39a3ee5e6b4b0d3255bfef95601890afd80709",
         ),
     ],
@@ -303,7 +303,7 @@ def test_DerivativesDataSink_build_path(
 
     if dismiss_entities:
         if "run" in dismiss_entities:
-            expectation = [e.replace("_run-1", "") for e in expectation]
+            expectation = [e.replace("_run-01", "") for e in expectation]
 
         if "session" in dismiss_entities:
             expectation = [
@@ -536,10 +536,10 @@ def test_DerivativesDataSink_fmapid(tmp_path):
     source_file = [
         (tmp_path / s)
         for s in [
-            "sub-36/fmap/sub-36_dir-1_run-1_epi.nii.gz",
-            "sub-36/fmap/sub-36_dir-1_run-2_epi.nii.gz",
-            "sub-36/fmap/sub-36_dir-2_run-1_epi.nii.gz",
-            "sub-36/fmap/sub-36_dir-2_run-2_epi.nii.gz",
+            "sub-36/fmap/sub-36_dir-1_run-01_epi.nii.gz",
+            "sub-36/fmap/sub-36_dir-1_run-02_epi.nii.gz",
+            "sub-36/fmap/sub-36_dir-2_run-01_epi.nii.gz",
+            "sub-36/fmap/sub-36_dir-2_run-02_epi.nii.gz",
         ]
     ]
     for fname in source_file:

--- a/niworkflows/tests/test_viz.py
+++ b/niworkflows/tests/test_viz.py
@@ -140,7 +140,7 @@ def test_fmriplot(input_files):
         _cifti_timeseries(in_file)
     )
 
-    fMRIPlot(
+    fig = fMRIPlot(
         timeseries,
         segments,
         tr=_get_tr(nb.load(in_file)),
@@ -151,10 +151,12 @@ def test_fmriplot(input_files):
         }),
         units={"FD": "mm"},
         paired_carpet=dtype == "cifti",
-    ).plot().savefig(
-        os.path.join(save_artifacts, f"fmriplot_{dtype}{has_seg}.svg"),
-        bbox_inches="tight",
-    )
+    ).plot()
+    if save_artifacts:
+        fig.savefig(
+            os.path.join(save_artifacts, f"fmriplot_{dtype}{has_seg}.svg"),
+            bbox_inches="tight",
+        )
 
 
 def test_plot_melodic_components(tmp_path):

--- a/niworkflows/utils/bids.py
+++ b/niworkflows/utils/bids.py
@@ -222,7 +222,7 @@ def collect_data(
             layout.get(
                 return_type="file",
                 subject=participant_label,
-                extension=["nii", "nii.gz"],
+                extension=[".nii", ".nii.gz"],
                 **query,
             )
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     numpy
     packaging
     pandas
-    pybids >= 0.11.1
+    pybids >= 0.15
     PyYAML
     scikit-image
     scipy


### PR DESCRIPTION
* fMRIPlot tests use `os.path.join(save_artifacts, ...)` which doesn't work when `save_artifacts` is a bool.
* PyBIDS 0.15 (released today) breaks tests that assume zero-padding on run entities is stripped. Let's just require 0.15+
* While we're at it, add some dots to some extensions.