### PR TITLE
FIX: Alternate query for template brain mask

### DIFF
--- a/niworkflows/interfaces/norm.py
+++ b/niworkflows/interfaces/norm.py
@@ -444,7 +444,7 @@ cannot be found."""
             # Get the template specified by the user.
             ref_mask = get_template(
                 self.inputs.template, desc="brain", suffix="mask", **template_spec
-            )
+            ) or get_template(self.inputs.template, label="brain", suffix="mask", **template_spec)
 
             # Default is explicit masking disabled
             args["fixed_image"] = ref_template


### PR DESCRIPTION
Catches cases where the brain mask is under the `label` entity (i.e. UNCInfant).

This should address the problem in nipreps/nibabies#187