### PR TITLE
REL: 1.5.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,18 @@
+1.5.3 (April 05, 2022)
+======================
+
+A bugfix release incorporating changes from the 1.3.x and 1.4.x
+maintenance series.
+
+* FIX: Alternate query for template brain mask (#704)
+* FIX: Use copy function that does not preserve mtime when creating fsaverage directories (#703)
+* FIX: Test failures (#701)
+* ENH: Add optional session filter when collecting data (#678)
+* ENH: Specify path pattern for transformation files in dwi datatype (#699)
+* REF: Move BIDS skeleton generation into new ``testing`` module (#682)
+* MNT: Select magnitude images in collect_data for BIDS 1.5.0 (#594)
+* CI: Install package across Python versions and run pytest (#697)
+
 1.5.2 (March 23, 2022)
 ======================
 A bugfix release ensuring compatibility with Python 3.7.

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ python_requires = >= 3.7
 install_requires =
     attrs
     jinja2
-    markupsafe ~= 2.0.1  # jinja2 imports deprecated function removed in 2.1
     matplotlib >= 3.4.2
     nibabel ~= 3.0
     nilearn >= 0.5.2


### PR DESCRIPTION
Doing a PR first to verify that it's now safe to remove the `markupsafe` pin.