### PR TITLE
ENH: Add `affine_tolerance` flag to `MergeSeries`

### DIFF
--- a/niworkflows/interfaces/nibabel.py
+++ b/niworkflows/interfaces/nibabel.py
@@ -160,6 +160,7 @@ class _MergeSeriesInputSpec(BaseInterfaceInputSpec):
     allow_4D = traits.Bool(
         True, usedefault=True, desc="whether 4D images are allowed to be concatenated"
     )
+    affine_tolerance = traits.Float(desc="Absolute tolerance allowed between image affines")
 
 
 class _MergeSeriesOutputSpec(TraitedSpec):
@@ -174,8 +175,17 @@ class MergeSeries(SimpleInterface):
 
     def _run_interface(self, runtime):
         nii_list = []
+        aff0 = None
         for f in self.inputs.in_files:
             filenii = nb.squeeze_image(nb.load(f))
+            if self.inputs.affine_tolerance:
+                if aff0 is None:
+                    aff0 = filenii.affine
+                elif not np.allclose(aff0, filenii.affine, atol=self.inputs.affine_tolerance):
+                    raise ValueError(
+                        "Difference in affines greater than allowed tolerance "
+                        f"{self.inputs.affine_tolerance}"
+                    )
             ndim = filenii.dataobj.ndim
             if ndim == 3:
                 nii_list.append(filenii)
@@ -188,7 +198,10 @@ class MergeSeries(SimpleInterface):
                     "Input image has an incorrect number of dimensions" f" ({ndim})."
                 )
 
-        img_4d = nb.concat_images(nii_list)
+        img_4d = nb.concat_images(
+            nii_list,
+            check_affines=not bool(self.inputs.affine_tolerance)
+        )
         out_file = fname_presuffix(
             self.inputs.in_files[0], suffix="_merged", newpath=runtime.cwd
         )

--- a/niworkflows/interfaces/tests/test_nibabel.py
+++ b/niworkflows/interfaces/tests/test_nibabel.py
@@ -155,3 +155,21 @@ def test_MergeSeries(tmp_path):
 
     with pytest.raises(ValueError):
         MergeSeries(in_files=[str(in_file)] + [str(in_4D)], allow_4D=False).run()
+
+
+def test_MergeSeries_affines(tmp_path):
+    os.chdir(str(tmp_path))
+
+    files = ['img0.nii.gz', 'img1.nii.gz']
+    data = np.ones((10, 10, 10), dtype=int)
+    aff = np.eye(4)
+    nb.Nifti1Image(data, aff, None).to_filename(files[0])
+    # slightly alter affine
+    aff[0][0] = 1.00005
+    nb.Nifti1Image(data, aff, None).to_filename(files[1])
+
+    # affine mismatch will cause this to fail
+    with pytest.raises(ValueError):
+        MergeSeries(in_files=files).run()
+    # but works if we set a tolerance
+    MergeSeries(in_files=files, affine_tolerance=1e-04).run()


### PR DESCRIPTION
This should help clear up the error found in https://github.com/nipreps/fmriprep/issues/2706