### PR TITLE
REL: 1.6.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,18 @@
+1.6.0 (May 25, 2022)
+====================
+New feature release in the 1.6.x series. This series will support sMRIPrep 0.9,
+fMRIPrep 22.0., and nibabies 22.1.
+
+* FIX: Address some reliability issues of the functional masking workflow (#714)
+* FIX: Improve reliability of BOLD masking workflow (#712)
+* FIX: Account for potential lists of lists in multi-echo cases (#719)
+* ENH: Added MRtrix3 gradients to derivative path patterns (#724)
+* ENH: Add T2starmap as a functional derivative (#720)
+* MAINT: Replace distutils use, upgrade versioneer (#725)
+* CI: Let datalad handle git-annex installation (#721)
+* CI: Bump environment cache version (#717)
+* CI: Fallback to maintenance branch first (#716)
+
 1.5.4 (April 08, 2022)
 ======================
 Bug-fix release in the 1.5.x series.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM nipreps/miniconda:py38_1.4.2
+FROM nipreps/miniconda:py39_2205.0
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:${CONDA_PATH}/lib"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -234,13 +234,13 @@ apidoc_extra_args = ["--module-first", "-d 1", "-T"]
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "bids": ("https://bids-standard.github.io/pybids/", None),
-    "matplotlib": ("https://matplotlib.org/", None),
+    "matplotlib": ("https://matplotlib.org/stable", None),
     "nibabel": ("https://nipy.org/nibabel/", None),
     "nipype": ("https://nipype.readthedocs.io/en/latest/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/dev", None),
     "python": ("https://docs.python.org/3/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy-1.8.0/html-scipyorg/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "smriprep": ("https://www.nipreps.org/smriprep/", None),
     "surfplot": ("https://surfplot.readthedocs.io/en/latest/", None),
     "templateflow": ("https://www.templateflow.org/python-client", None),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,21 @@
 #
 import os
 import sys
+from unittest import mock
+import tempfile
+
 from packaging.version import Version
+import templateflow
+
+# Prevent etelemetry from loading at all
+# Could set NO_ET environment variable, but why?
+sys.modules["etelemetry"] = mock.Mock()
+
+# Keep templateflow API intact except for fetching files.
+# Return an existent but empty temporary file
+tffiledesc, tffilename = tempfile.mkstemp()
+os.close(tffiledesc)
+templateflow.api.get = mock.MagicMock(return_value=tffilename)
 
 from niworkflows import __version__, __copyright__, __packagename__
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,15 @@ import templateflow
 
 # Prevent etelemetry from loading at all
 # Could set NO_ET environment variable, but why?
-sys.modules["etelemetry"] = mock.Mock()
+MOCKS = [
+    "etelemetry",
+    "matplotlib",
+    "matplotlib.pyplot",
+    "matplotlib.cm",
+    "matplotlib.colors",
+    "matplotlib.colorbar",
+]
+sys.modules.update({mod: mock.Mock() for mod in MOCKS})
 
 # Keep templateflow API intact except for fetching files.
 # Return an existent but empty temporary file
@@ -61,7 +69,6 @@ extensions = [
 ]
 
 autodoc_mock_imports = [
-    "matplotlib",
     "nilearn",
     "nitime",
     "numpy",
@@ -71,6 +78,7 @@ autodoc_mock_imports = [
     "svgutils",
     "templateflow",
     "transforms3d",
+    "yaml",
 ]
 
 # Accept custom section names to be parsed for numpy-style docstrings

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,14 +1,8 @@
-networkx != 2.8.1
-furo ~= 2021.10.09
-matplotlib >= 2.2.0
-nibabel
+attrs
+furo ~= 2022.04.07
 nipype >= 1.5.1
-numpy
 packaging
-pydot >= 1.2.3
-pydotplus
 sphinx ~= 4.2
 sphinxcontrib-apidoc
 sphinxcontrib-napoleon
 templateflow
-nitransforms >= 20.0.0rc3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 attrs
-furo ~= 2022.04.07
+furo ~= 2022.4.7
 nipype >= 1.5.1
 packaging
 sphinx ~= 4.2


### PR DESCRIPTION
Prepare 1.6.0 release.

@mgxd Is there any reason we should include some of these fixes in 1.5.x? We could do a 1.5.5 release with the old miniconda image and a 1.6.0 with the new.