### PR TITLE
MAINT: Test if prereleases are compatible now

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,9 +46,6 @@ install_requires =
     svgutils >= 0.3.4
     transforms3d
     templateflow >= 0.7.2
-    # currently breaking tests
-    aiohttp<4
-    vtk!=9.2.0rc1
 test_requires =
     coverage >=5.2.1
     pytest >= 4.4


### PR DESCRIPTION
Since these are not first-class dependencies, we shouldn't be managing them.