### PR TITLE
MAINT: Remove pins that broke prerelease tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,9 +46,6 @@ install_requires =
     svgutils >= 0.3.4
     transforms3d
     templateflow >= 0.7.2
-    # currently breaking tests
-    aiohttp<4
-    vtk!=9.2.0rc1
 test_requires =
     coverage >=5.2.1
     pytest >= 4.4


### PR DESCRIPTION
Now that wslink / brainspace incompatibilities are merged and released.