### PR TITLE
MNT: Pin traits < 6.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     nibabel >= 3.0
     nilearn >= 0.5.2
     nipype ~= 1.5, != 1.7.0
+    traits < 6.4
     nitransforms >= 21.0.0
     numpy
     packaging


### PR DESCRIPTION
This pin should probably also go in nipype, as the [6.4.0 release notes](https://github.com/enthought/traits/releases/tag/6.4.0) indicate they're deprecating `Either` and changing the semantics of `Tuple`.