### PR TITLE
ENH: Add `minimum_fs_version` input to handle outdated `fsaverage`s

### DIFF
--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -848,6 +848,7 @@ class _BIDSFreeSurferDirInputSpec(BaseInterfaceInputSpec):
     overwrite_fsaverage = traits.Bool(
         False, usedefault=True, desc="Overwrite fsaverage directories, if present"
     )
+    minimum_fs_version = traits.Enum("7.0.0", desc="Minimum FreeSurfer version for compatibility")
 
 
 class _BIDSFreeSurferDirOutputSpec(TraitedSpec):
@@ -910,6 +911,12 @@ class BIDSFreeSurferDir(SimpleInterface):
                     continue
                 else:
                     raise FileNotFoundError("Expected to find '%s' to copy" % source)
+
+            if dest.exists() and self.inputs.minimum_fs_version == "7.0.0":
+                label = dest / 'label' / 'rh.FG1.mpm.vpnl.label'  # new in FS7
+                if not label.exists():
+                    # remove previous output and let us recopy
+                    shutil.rmtree(dest)
 
             # Finesse is overrated. Either leave it alone or completely clobber it.
             if dest.exists() and self.inputs.overwrite_fsaverage:

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -912,7 +912,11 @@ class BIDSFreeSurferDir(SimpleInterface):
                 else:
                     raise FileNotFoundError("Expected to find '%s' to copy" % source)
 
-            if dest.exists() and self.inputs.minimum_fs_version == "7.0.0":
+            if (
+                space == 'fsaverage'
+                and dest.exists()
+                and self.inputs.minimum_fs_version == "7.0.0"
+            ):
                 label = dest / 'label' / 'rh.FG1.mpm.vpnl.label'  # new in FS7
                 if not label.exists():
                     # remove previous output and let us recopy

--- a/niworkflows/interfaces/tests/test_bids.py
+++ b/niworkflows/interfaces/tests/test_bids.py
@@ -705,13 +705,13 @@ def test_fsdir_min_version(tmp_path, min_version):
     fshome = os.environ["FREESURFER_HOME"]
     subjects_dir = tmp_path / "freesurfer"
 
-    patched_subject_dir = subjects_dir / 'fsaverage6' / 'older'
+    patched_subject_dir = subjects_dir / 'fsaverage' / 'older'
     patched_subject_dir.mkdir(parents=True)
 
     bfsd = bintfs.BIDSFreeSurferDir(
         subjects_dir=subjects_dir,
         derivatives=str(tmp_path),
-        spaces=["fsaverage6"],
+        spaces=["fsaverage"],
         freesurfer_home=fshome,
     )
 

--- a/niworkflows/interfaces/tests/test_bids.py
+++ b/niworkflows/interfaces/tests/test_bids.py
@@ -697,3 +697,30 @@ def test_fsdir_missing_space(tmp_path):
     bintfs.BIDSFreeSurferDir(
         derivatives=str(tmp_path), spaces=["fsaverage2"], freesurfer_home=fshome
     ).run()
+
+
+@pytest.mark.skipif(not os.getenv("FREESURFER_HOME"), reason="No FreeSurfer")
+@pytest.mark.parametrize('min_version', [None, '7.0.0'])
+def test_fsdir_min_version(tmp_path, min_version):
+    fshome = os.environ["FREESURFER_HOME"]
+    subjects_dir = tmp_path / "freesurfer"
+
+    patched_subject_dir = subjects_dir / 'fsaverage6' / 'older'
+    patched_subject_dir.mkdir(parents=True)
+
+    bfsd = bintfs.BIDSFreeSurferDir(
+        subjects_dir=subjects_dir,
+        derivatives=str(tmp_path),
+        spaces=["fsaverage6"],
+        freesurfer_home=fshome,
+    )
+
+    if min_version:
+        bfsd.inputs.minimum_fs_version = min_version
+
+    bfsd.run()
+    if min_version:
+        # should have been overwritten with proper subjects dir
+        assert not patched_subject_dir.exists()
+    else:
+        assert patched_subject_dir.exists()


### PR DESCRIPTION
This addresses an issue that popped up in https://github.com/poldracklab/tacc-openneuro/issues/23 - with the FS7 migration, we should be aware that fsaverage directories generated from previous FS versions are incomplete and will lead to errors.

This proposes a new input, `minimum_fs_version`, which checks if the `<space>` directory includes newer files. If not, it will remove it and make a fresh copy.