### PR TITLE
CI: Extract pip pre checks into separate, skippable job

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,8 +14,28 @@ on:
 
 
 jobs:
+  check_if_skip:
+    runs-on: ubuntu-latest
+    outputs:
+      commit_message: ${{ steps.get_commit_message.outputs.commit_message }}
+    steps:
+      - name: Get repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Print head git commit message
+        id: get_commit_message
+        run: |
+          COMMIT_MSG=${{ github.event.head_commit.message }}
+          if [[ -z $COMMIT_MSG ]]; then
+            COMMIT_MSG=$(git show -s --format=%s)
+          fi
+          echo $COMMIT_MSG
+          echo "::set-output name=commit_message::$COMMIT_MSG"
+
   build:
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    needs: check_if_skip
+    if: "!contains(needs.check_if_skip.outputs.commit_message, '[skip ci]')"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -95,17 +115,90 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
         install: [repo]
-        pip-flags: ['', '--pre']
         include:
           - python-version: 3.9
             install: sdist
-            pip-flags: ''
           - python-version: 3.9
             install: wheel
-            pip-flags: ''
           - python-version: 3.9
             install: editable
-            pip-flags: ''
+
+    env:
+      INSTALL_TYPE: ${{ matrix.install }}
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Load test data cache
+      uses: actions/cache@v2
+      id: stanford-crn
+      with:
+        path: ~/.cache/stanford-crn/
+        key: data-v0-${{ github.ref_name }}-${{ github.sha }}
+    - name: Load TemplateFlow cache
+      uses: actions/cache@v2
+      id: templateflow
+      with:
+        path: ~/.cache/templateflow
+        key: templateflow-v0-${{ github.ref_name }}-${{ strategy.job-index }}-${{ github.sha }}
+        restore-keys: |
+          templateflow-v0-${{ github.ref_name }}-
+          templateflow-v0-
+    - name: Fetch packages
+      uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist/
+    - name: Select archive
+      run: |
+        if [ "$INSTALL_TYPE" = "sdist" ]; then
+          ARCHIVE=$( ls dist/*.tar.gz )
+        elif [ "$INSTALL_TYPE" = "wheel" ]; then
+          ARCHIVE=$( ls dist/*.whl )
+        elif [ "$INSTALL_TYPE" = "repo" ]; then
+          ARCHIVE="."
+        elif [ "$INSTALL_TYPE" = "editable" ]; then
+          ARCHIVE="-e ."
+        fi
+        echo "ARCHIVE=$ARCHIVE" >> $GITHUB_ENV
+    - name: Install package
+      run: python -m pip install $ARCHIVE
+    - name: Check version
+      run: |
+        # Interpolate version
+        if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+          TAG=${GITHUB_REF##*/}
+        fi
+        THISVERSION=$( python get_version.py )
+        THISVERSION=${TAG:-$THISVERSION}
+        INSTALLED_VERSION=$(python -c 'import niworkflows; print(niworkflows.__version__, end="")')
+        echo "VERSION: \"${THISVERSION}\""
+        echo "INSTALLED: \"${INSTALLED_VERSION}\""
+        test "${INSTALLED_VERSION}" = "${THISVERSION}"
+    - name: Install test dependencies
+      run: python -m pip install "niworkflows[tests]"
+    - name: Run tests
+      uses: GabrielBB/xvfb-action@v1
+      with:
+        run: pytest -sv --no-xvfb --doctest-modules --cov niworkflows niworkflows
+    - uses: codecov/codecov-action@v2
+      name: Submit to CodeCov
+
+  test-pre:
+    needs: [build, get_data, check_if_skip]
+    if: ${{ !contains(needs.check_if_skip.outputs.commit_message, '[skip pre]') }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+        install: [repo]
+        pip-flags: ['--pre']
+        include:
           # VTK won't build official 3.10 wheels before 9.2.0
           # PyVista has posted dev versions, at least
           - python-version: '3.10'
@@ -117,6 +210,8 @@ jobs:
       PIP_FLAGS: ${{ matrix.pip-flags }}
 
     steps:
+    - name: Debug commit message
+      run: echo "${{ needs.check_if_skip.outputs.commit_message }}"
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
@@ -180,7 +275,8 @@ jobs:
       name: Submit to CodeCov
 
   flake8:
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    needs: check_if_skip
+    if: "!contains(needs.check_if_skip.outputs.commit_message, '[skip ci]')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Since github actions does not yet support early, successful job termination(!), this required splitting the test/install into separate stable and pre-release jobs.