### PR TITLE
CI: Fix commit check

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -26,12 +26,13 @@ jobs:
       - name: Print head git commit message
         id: get_commit_message
         run: |
-          COMMIT_MSG=${{ github.event.head_commit.message }}
-          if [[ -z $COMMIT_MSG ]]; then
+          if [[ -z "$COMMIT_MSG" ]]; then
             COMMIT_MSG=$(git show -s --format=%s)
           fi
           echo $COMMIT_MSG
           echo "::set-output name=commit_message::$COMMIT_MSG"
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
 
   build:
     needs: check_if_skip


### PR DESCRIPTION
GitHub string interpolation seems to break in the run portion. Use `env` instead. We could probably also just quote it...