### PR TITLE
REF: Store global variables as DerivativesDataSink attributes

### DIFF
--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -506,7 +506,7 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
     def __init__(self, allowed_entities=None, out_path_base=None, **inputs):
         """Initialize the SimpleInterface and extend inputs with custom entities."""
         self._allowed_entities = set(allowed_entities or []).union(
-            self._allowed_entities
+            set(self._config_entities)
         )
         if out_path_base:
             self.out_path_base = out_path_base

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -502,6 +502,7 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
     _allowed_entities = set(_config_entities)
     _standard_spaces = STANDARD_SPACES
     _file_patterns = BIDS_DERIV_PATTERNS
+    _default_dtypes = DEFAULT_DTYPES
 
     def __init__(self, allowed_entities=None, out_path_base=None, **inputs):
         """Initialize the SimpleInterface and extend inputs with custom entities."""
@@ -651,7 +652,7 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
             is_nifti = out_file.name.endswith(
                 (".nii", ".nii.gz")
             ) and not out_file.name.endswith((".dtseries.nii", ".dtseries.nii.gz"))
-            data_dtype = self.inputs.data_dtype or DEFAULT_DTYPES[self.inputs.suffix]
+            data_dtype = self.inputs.data_dtype or self._default_dtypes[self.inputs.suffix]
             if is_nifti and any((self.inputs.check_hdr, data_dtype)):
                 nii = nb.load(orig_file)
 

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -499,7 +499,6 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
     out_path_base = "niworkflows"
     _always_run = True
     _config_entities = BIDS_DERIV_ENTITIES
-    _allowed_entities = set(_config_entities)
     _standard_spaces = STANDARD_SPACES
     _file_patterns = BIDS_DERIV_PATTERNS
     _default_dtypes = DEFAULT_DTYPES
@@ -599,7 +598,7 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
             out_entities["extension"] = out_entities["extension"][0]
 
         # Insert custom (non-BIDS) entities from allowed_entities.
-        custom_entities = set(out_entities.keys()) - set(self._config_entities)
+        custom_entities = set(out_entities) - set(self._config_entities)
         patterns = self._file_patterns
         if custom_entities:
             # Example: f"{key}-{{{key}}}" -> "task-{task}"

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -498,7 +498,10 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
     output_spec = _DerivativesDataSinkOutputSpec
     out_path_base = "niworkflows"
     _always_run = True
-    _allowed_entities = set(BIDS_DERIV_ENTITIES)
+    _config_entities = BIDS_DERIV_ENTITIES
+    _allowed_entities = set(_config_entities)
+    _standard_spaces = STANDARD_SPACES
+    _file_patterns = BIDS_DERIV_PATTERNS
 
     def __init__(self, allowed_entities=None, out_path_base=None, **inputs):
         """Initialize the SimpleInterface and extend inputs with custom entities."""
@@ -585,7 +588,7 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
         space = out_entities.get("space")
         if resolution:
             # Standard spaces
-            if space in STANDARD_SPACES:
+            if space in self._standard_spaces:
                 res = _get_tf_resolution(space, resolution)
             else:  # TODO: Nonstandard?
                 res = "Unknown"
@@ -595,8 +598,8 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
             out_entities["extension"] = out_entities["extension"][0]
 
         # Insert custom (non-BIDS) entities from allowed_entities.
-        custom_entities = set(out_entities.keys()) - set(BIDS_DERIV_ENTITIES)
-        patterns = BIDS_DERIV_PATTERNS
+        custom_entities = set(out_entities.keys()) - set(self._config_entities)
+        patterns = self._file_patterns
         if custom_entities:
             # Example: f"{key}-{{{key}}}" -> "task-{task}"
             custom_pat = "_".join(f"{key}-{{{key}}}" for key in sorted(custom_entities))
@@ -667,7 +670,7 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
                     xcodes = (1, 1)  # Derivative in its original scanner space
                     if self.inputs.space:
                         xcodes = (
-                            (4, 4) if self.inputs.space in STANDARD_SPACES else (2, 2)
+                            (4, 4) if self.inputs.space in self._standard_spaces else (2, 2)
                         )
 
                     curr_zooms = zooms = hdr.get_zooms()


### PR DESCRIPTION
Closes #757. I'm not sure how I should test this, given there is only one config file in niworkflows at the moment.

Changes proposed:

- Store the entity and filename config variables (currently stored as globals) as attributes in DerivativesDataSink. This will hopefully make it easier for other packages to build child classes from DerivativesDataSink, with their own config info.