### PR TITLE
CI: Drop set-output

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -37,8 +37,6 @@ jobs:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
 
   build:
-    needs: check_if_skip
-    if: "!contains(needs.check_if_skip.outputs.commit_message, '[skip ci]')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -252,8 +250,6 @@ jobs:
       name: Submit to CodeCov
 
   flake8:
-    needs: check_if_skip
-    if: "!contains(needs.check_if_skip.outputs.commit_message, '[skip ci]')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,8 +32,7 @@ jobs:
           if [[ -z "$COMMIT_MSG" ]]; then
             COMMIT_MSG=$(git show -s --format=%s)
           fi
-          echo $COMMIT_MSG
-          echo "::set-output name=commit_message::$COMMIT_MSG"
+          echo commit_message=$COMMIT_MSG | tee -a $GITHUB_OUTPUT
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
 


### PR DESCRIPTION
Addressing GitHub actions warning:

>  check_if_skip
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
