### PR TITLE
Fix error for `np.bool` with `numpy 1.24.0`

### DIFF
--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -975,7 +975,7 @@ def confounds_correlation_plot(
     ax0 = plt.subplot(gs[0, :10])
     ax1 = plt.subplot(gs[0, 11:])
 
-    mask = np.zeros_like(corr, dtype=np.bool)
+    mask = np.zeros_like(corr, dtype=bool)
     mask[np.triu_indices_from(mask)] = True
     sns.heatmap(corr, linewidths=0.5, cmap="coolwarm", center=0, square=True, ax=ax0)
     ax0.tick_params(axis="both", which="both", width=0)


### PR DESCRIPTION
Using `np.bool` has been deprecated since `numpy 1.20.0` and was removed with the most recent release. For more information, see <https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated>. The recommended alternative is to simply use the built-in `bool`. 

In this pull request, I apply the recommended alternative in one line.

```
Traceback (most recent call last):
  File "/usr/local/miniconda/lib/python3.11/site-packages/nipype/interfaces/base/core.py", line 398, in run
	  runtime = self._run_interface(runtime)
	            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/miniconda/lib/python3.11/site-packages/niworkflows/interfaces/plotting.py", line 177, in _run_interface
	  confounds_correlation_plot(
  File "/usr/local/miniconda/lib/python3.11/site-packages/niworkflows/viz/plots.py", line 978, in confounds_correlation_plot
	  mask = np.zeros_like(corr, dtype=np.bool)
	                                   ^^^^^^^
  File "/usr/local/miniconda/lib/python3.11/site-packages/numpy/__init__.py", line 284, in __getattr__
	  raise AttributeError("module {!r} has no attribute "
  AttributeError: module 'numpy' has no attribute 'bool'
```