### PR TITLE
FIX: Remove unused ANTs parameter that was removed in 2.4.1

### DIFF
--- a/niworkflows/data/boldref-mni_registration_precise_000.json
+++ b/niworkflows/data/boldref-mni_registration_precise_000.json
@@ -17,7 +17,6 @@
     "smoothing_sigmas": [ [ 4, 2, 1 ], [ 4, 2, 1 ], [ 3, 2, 1 ] ],
     "transform_parameters": [ [ 0.05 ], [ 0.08 ], [ 0.1, 3.0, 0.0 ] ],
     "transforms": [ "Rigid", "Affine", "SyN" ],
-    "use_estimate_learning_rate_once": [ true, true, true ],
     "use_histogram_matching": [ true, true, true ],
     "winsorize_lower_quantile": 0.005,
     "winsorize_upper_quantile": 0.995,

--- a/niworkflows/data/boldref-mni_registration_precise_001.json
+++ b/niworkflows/data/boldref-mni_registration_precise_001.json
@@ -15,7 +15,6 @@
     "sigma_units": [ "vox", "vox", "vox" ],
     "winsorize_upper_quantile": 0.9995,
     "winsorize_lower_quantile": 0.01,
-    "use_estimate_learning_rate_once": [ true, true, false ],
     "use_histogram_matching": [ true, true, true ],
     "collapse_output_transforms": true,
     "write_composite_transform": false,

--- a/niworkflows/data/boldref-mni_registration_precise_002.json
+++ b/niworkflows/data/boldref-mni_registration_precise_002.json
@@ -15,7 +15,6 @@
     "shrink_factors": [ [ 4, 2, 1 ], [ 4, 4, 2, 1 ], [ 4, 2, 1 ] ],
     "winsorize_upper_quantile": 0.995,
     "winsorize_lower_quantile": 0.005,
-    "use_estimate_learning_rate_once": [ true, true, true ],
     "use_histogram_matching": [ false, false, true ],
     "collapse_output_transforms": true,
     "write_composite_transform": false,

--- a/niworkflows/data/boldref-mni_registration_testing_000.json
+++ b/niworkflows/data/boldref-mni_registration_testing_000.json
@@ -15,7 +15,6 @@
     "sigma_units": [ "mm", "mm", "mm" ],
     "winsorize_upper_quantile": 0.995,
     "winsorize_lower_quantile": 0.001,
-    "use_estimate_learning_rate_once": [ true, true, true ],
     "use_histogram_matching": [ true, true, true ],
     "collapse_output_transforms": true,
     "write_composite_transform": false,

--- a/niworkflows/data/boldref-mni_registration_testing_001.json
+++ b/niworkflows/data/boldref-mni_registration_testing_001.json
@@ -13,7 +13,6 @@
     "shrink_factors": [ [ 1 ], [ 1 ], [ 1 ] ],
     "smoothing_sigmas": [ [ 4 ], [ 0 ], [ 0 ] ],
     "sigma_units": [ "mm", "mm", "mm" ],
-    "use_estimate_learning_rate_once": [ true, true, false ],
     "use_histogram_matching": [ true, true, false ],
     "winsorize_upper_quantile": 0.999,
     "winsorize_lower_quantile": 0.005,

--- a/niworkflows/data/boldref-mni_registration_testing_002.json
+++ b/niworkflows/data/boldref-mni_registration_testing_002.json
@@ -13,7 +13,6 @@
     "shrink_factors": [ [ 2 ], [ 1 ] ],
     "smoothing_sigmas": [ [ 4 ], [ 0 ] ],
     "sigma_units": [ "mm", "mm" ],
-    "use_estimate_learning_rate_once": [ true, true ],
     "use_histogram_matching": [ true, true ],
     "winsorize_upper_quantile": 0.999,
     "winsorize_lower_quantile": 0.005,

--- a/niworkflows/data/epi_atlasbased_brainmask.json
+++ b/niworkflows/data/epi_atlasbased_brainmask.json
@@ -15,6 +15,5 @@
     "sigma_units": ["mm", "mm", "mm"],
     "shrink_factors": [[2]],
     "sampling_percentage": [0.2],
-    "use_histogram_matching": [true],
-    "use_estimate_learning_rate_once": [true]
+    "use_histogram_matching": [true]
 }

--- a/niworkflows/data/t1w-mni_registration_fast_000.json
+++ b/niworkflows/data/t1w-mni_registration_fast_000.json
@@ -17,7 +17,6 @@
     "smoothing_sigmas": [ [ 4 ], [ 4, 2, 0 ], [ 1, 0 ] ],
     "transform_parameters": [ [ 0.01 ], [ 0.08 ], [ 0.1, 3.0, 0.0 ] ],
     "transforms": [ "Rigid", "Affine", "SyN" ],
-    "use_estimate_learning_rate_once": [ true, true, true ],
     "use_histogram_matching": [ true, true, true ],
     "write_composite_transform": false
 }

--- a/niworkflows/data/t1w-mni_registration_precise_000.json
+++ b/niworkflows/data/t1w-mni_registration_precise_000.json
@@ -37,7 +37,6 @@
     [0.1, 3.0, 0.0]
   ],
   "transforms": ["Rigid", "Affine", "SyN"],
-  "use_estimate_learning_rate_once": [true, true, true],
   "use_histogram_matching": [true, true, true],
   "winsorize_lower_quantile": 0.005,
   "winsorize_upper_quantile": 0.995,

--- a/niworkflows/data/t1w-mni_registration_precise_001.json
+++ b/niworkflows/data/t1w-mni_registration_precise_001.json
@@ -15,7 +15,6 @@
     "shrink_factors": [ [ 2, 1 ], [ 2, 1 ], [ 4, 2, 1 ] ],
     "winsorize_upper_quantile": 0.995,
     "winsorize_lower_quantile": 0.005,
-    "use_estimate_learning_rate_once": [ true, true, true ],
     "use_histogram_matching": [ false, false, true ],
     "collapse_output_transforms": true,
     "write_composite_transform": false,

--- a/niworkflows/data/t1w-mni_registration_precise_002.json
+++ b/niworkflows/data/t1w-mni_registration_precise_002.json
@@ -15,7 +15,6 @@
     "shrink_factors": [ [ 2, 1 ], [ 2, 1 ], [ 4, 2, 1 ] ],
     "winsorize_upper_quantile": 0.995,
     "winsorize_lower_quantile": 0.005,
-    "use_estimate_learning_rate_once": [ true, true, true ],
     "use_histogram_matching": [ false, false, true ],
     "collapse_output_transforms": true,
     "write_composite_transform": false,

--- a/niworkflows/data/t1w-mni_registration_testing_000.json
+++ b/niworkflows/data/t1w-mni_registration_testing_000.json
@@ -29,7 +29,6 @@
     [1.0]
   ],
   "transforms": ["Rigid", "Affine"],
-  "use_estimate_learning_rate_once": [true, true],
   "use_histogram_matching": [false, true],
   "winsorize_lower_quantile": 0.005,
   "winsorize_upper_quantile": 0.995,

--- a/niworkflows/data/t1w-mni_registration_testing_001.json
+++ b/niworkflows/data/t1w-mni_registration_testing_001.json
@@ -15,7 +15,6 @@
     "shrink_factors": [[2], [1]],
     "winsorize_upper_quantile": 0.995,
     "winsorize_lower_quantile": 0.005,
-    "use_estimate_learning_rate_once": [ true, true ],
     "use_histogram_matching": [ false, true ],
     "collapse_output_transforms": true,
     "write_composite_transform": false,

--- a/niworkflows/data/t1w-mni_registration_testing_002.json
+++ b/niworkflows/data/t1w-mni_registration_testing_002.json
@@ -15,7 +15,6 @@
     "shrink_factors": [[2], [1]],
     "winsorize_upper_quantile": 0.995,
     "winsorize_lower_quantile": 0.005,
-    "use_estimate_learning_rate_once": [ true, true ],
     "use_histogram_matching": [ false, true ],
     "collapse_output_transforms": true,
     "write_composite_transform": false,


### PR DESCRIPTION
Backporting #771 and #770 to the LTS branch.