### PR TITLE
MAINT: Update ``FS_LICENSE`` (from context) and docker orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  docker: circleci/docker@1.6.0
+  docker: circleci/docker@2.2.0
 
 jobs:
   build:
@@ -159,7 +159,7 @@ jobs:
           command: |
             mkdir -p /tmp/fslicense
             cd /tmp/fslicense
-            echo "cHJpbnRmICJrcnp5c3p0b2YuZ29yZ29sZXdza2lAZ21haWwuY29tXG41MTcyXG4gKkN2dW12RVYzelRmZ1xuRlM1Si8yYzFhZ2c0RVxuIiA+IGxpY2Vuc2UudHh0Cg==" | base64 -d | sh
+            echo "${FS_LICENSE_CONTENT}" | base64 -d | sh
 
       - checkout:
           path: /tmp/src/niworkflows
@@ -407,6 +407,8 @@ workflows:
             tags:
               only: /.*/
       - get_data:
+          context:
+            - fs-license
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
- Avoid having the license encoded string directly in the config file (e.g., if we are requested to stop using Chris G's)
- Update docker orb version (although I don't think we are using the orb at any moment -- not just niworkflows, btw).