### PR TITLE
FIX: Handle plotting only one MELODIC component

### DIFF
--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -643,7 +643,11 @@ def plot_melodic_components(
         ax.axes.get_yaxis().set_visible(False)
 
     titlefmt = "C{id:d}{noise}: Tot. var. expl. {var:.2g}%".format
-    for i, img in enumerate(iter_img(os.path.join(melodic_dir, "melodic_IC.nii.gz"))):
+    ICs = nb.load(os.path.join(melodic_dir, "melodic_IC.nii.gz"))
+    # Ensure 4D
+    if ICs.ndim == 3:
+        ICs = ICs.slicer[..., None]
+    for i, img in enumerate(iter_img(ICs)):
 
         col = i % 2
         row = i // 2


### PR DESCRIPTION
This addresses https://github.com/poldracklab/tacc-openneuro/issues/40.

It's a rare case, but if the series can be 3D, we should be handle it.