### PR TITLE
Pass custom configuration into DerivativesDataSink entity parser

### DIFF
--- a/niworkflows/data/nipreps.json
+++ b/niworkflows/data/nipreps.json
@@ -34,7 +34,7 @@
     },
     {
       "name": "run",
-      "pattern": "[_/\\\\]+run-*(\\d+)",
+      "pattern": "[_/\\\\]+run-(\\d+)",
       "dtype": "int"
     },
     {

--- a/niworkflows/data/nipreps.json
+++ b/niworkflows/data/nipreps.json
@@ -34,7 +34,7 @@
     },
     {
       "name": "run",
-      "pattern": "[_/\\\\]+run-0*(\\d+)",
+      "pattern": "[_/\\\\]+run-*(\\d+)",
       "dtype": "int"
     },
     {

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -55,7 +55,7 @@ from ..utils.misc import _copy_any, unlink
 
 regz = re.compile(r"\.gz$")
 _pybids_spec = loads(Path(_pkgres("niworkflows", "data/nipreps.json")).read_text())
-BIDS_DERIV_ENTITIES = frozenset({e["name"] for e in _pybids_spec["entities"]})
+BIDS_DERIV_ENTITIES = _pybids_spec["entities"]
 BIDS_DERIV_PATTERNS = tuple(_pybids_spec["default_path_patterns"])
 
 STANDARD_SPACES = tf.api.templates()
@@ -498,7 +498,8 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
     output_spec = _DerivativesDataSinkOutputSpec
     out_path_base = "niworkflows"
     _always_run = True
-    _config_entities = BIDS_DERIV_ENTITIES
+    _config_entities = frozenset({e["name"] for e in BIDS_DERIV_ENTITIES})
+    _config_entities_dict = BIDS_DERIV_ENTITIES
     _standard_spaces = STANDARD_SPACES
     _file_patterns = BIDS_DERIV_PATTERNS
     _default_dtypes = DEFAULT_DTYPES
@@ -551,7 +552,7 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
         # Initialize entities with those from the source file.
         custom_config = Config(
             name="custom",
-            entities=self._config_entities,
+            entities=self._config_entities_dict,
             default_path_patterns=self._file_patterns,
         )
         in_entities = [

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -526,7 +526,7 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
             setattr(self.inputs, k, inputs[k])
 
     def _run_interface(self, runtime):
-        from bids.layout import parse_file_entities
+        from bids.layout import parse_file_entities, Config
         from bids.layout.writing import build_path
         from bids.utils import listify
 
@@ -549,8 +549,16 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
             self._metadata = meta
 
         # Initialize entities with those from the source file.
+        custom_config = Config(
+            name="custom",
+            entities=self._config_entities,
+            default_path_patterns=self._file_patterns,
+        )
         in_entities = [
-            parse_file_entities(str(relative_to_root(source_file)))
+            parse_file_entities(
+                str(relative_to_root(source_file)),
+                config=["bids", "derivatives", custom_config],
+            )
             for source_file in self.inputs.source_file
         ]
         out_entities = {k: v for k, v in in_entities[0].items()

--- a/niworkflows/reports/core.py
+++ b/niworkflows/reports/core.py
@@ -272,7 +272,7 @@ class Report:
     >>> robj.generate_report()
     0
     >>> len((testdir / 'out' / 'fmriprep' / 'sub-01.html').read_text())
-    36693
+    36713
 
     .. testcleanup::
 

--- a/niworkflows/reports/core.py
+++ b/niworkflows/reports/core.py
@@ -63,6 +63,26 @@ reloading the report in your browser.</object>
 ]
 
 
+class Smallest:
+    """An object that always evaluates smaller than anything else, for sorting
+
+    >>> Smallest() < 1
+    True
+    >>> Smallest() < "epsilon"
+    True
+    >>> sorted([1, None, 2], key=lambda x: x if x is not None else Smallest())
+    [None, 1, 2]
+    """
+    def __lt__(self, other):
+        return not isinstance(other, Smallest)
+
+    def __eq__(self, other):
+        return isinstance(other, Smallest)
+
+    def __gt__(self, other):
+        return False
+
+
 class Element(object):
     """Just a basic component of a report"""
 
@@ -483,7 +503,7 @@ class Report:
         # sort the value combinations alphabetically from the first entity to the last entity
         value_combos.sort(
             key=lambda entry: tuple(
-                str(value) if value is not None else "0" for value in entry
+                value if value is not None else Smallest() for value in entry
             )
         )
 

--- a/niworkflows/reports/tests/test_core.py
+++ b/niworkflows/reports/tests/test_core.py
@@ -32,7 +32,6 @@ from yaml import safe_load as load
 import matplotlib.pyplot as plt
 from bids.layout.writing import build_path
 from bids.layout import BIDSLayout
-from bids.layout.utils import PaddedInt
 
 import pytest
 
@@ -153,11 +152,11 @@ def test_report2(bids_sessions):
             [
                 (None, "faketask"),
                 (None, "faketask2"),
-                (PaddedInt("01"), "faketaskwithruns"),
-                (PaddedInt("01"), "mixedgamblestask"),
-                (PaddedInt("02"), "faketaskwithruns"),
-                (PaddedInt("02"), "mixedgamblestask"),
-                (PaddedInt("03"), "mixedgamblestask"),
+                (1, "faketaskwithruns"),
+                (1, "mixedgamblestask"),
+                (2, "faketaskwithruns"),
+                (2, "mixedgamblestask"),
+                (3, "mixedgamblestask"),
             ],
         ),
         ([""], [], []),

--- a/niworkflows/reports/tests/test_core.py
+++ b/niworkflows/reports/tests/test_core.py
@@ -32,6 +32,7 @@ from yaml import safe_load as load
 import matplotlib.pyplot as plt
 from bids.layout.writing import build_path
 from bids.layout import BIDSLayout
+from bids.layout.utils import PaddedInt
 
 import pytest
 
@@ -152,11 +153,11 @@ def test_report2(bids_sessions):
             [
                 (None, "faketask"),
                 (None, "faketask2"),
-                (1, "faketaskwithruns"),
-                (1, "mixedgamblestask"),
-                (2, "faketaskwithruns"),
-                (2, "mixedgamblestask"),
-                (3, "mixedgamblestask"),
+                (PaddedInt("01"), "faketaskwithruns"),
+                (PaddedInt("01"), "mixedgamblestask"),
+                (PaddedInt("02"), "faketaskwithruns"),
+                (PaddedInt("02"), "mixedgamblestask"),
+                (PaddedInt("03"), "mixedgamblestask"),
             ],
         ),
         ([""], [], []),


### PR DESCRIPTION
Closes #776.

Changes proposed:
- Convert `DerivativesDataSink._config_entities` and `DerivativesDataSink._file_patterns` into a `bids.layout.Config` object, then feed this Config into `parse_file_entities` (along with the default `bids` and `derivatives` ones) in order to extract custom entities from the `source_file`.