### PR TITLE
FIX: Restore confound order in correlation plot

### DIFF
--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -900,9 +900,9 @@ def confounds_correlation_plot(
     confounds_data = pd.read_table(confounds_file)
 
     if columns:
-        columns = set(columns)  # Drop duplicates
-        columns.add(reference)  # Make sure the reference is included
-        confounds_data = confounds_data[[el for el in columns]]
+        columns = dict.fromkeys(columns)  # Drop duplicates
+        columns[reference] = None  # Make sure the reference is included
+        confounds_data = confounds_data[list(columns)]
 
     confounds_data = confounds_data.loc[
         :, np.logical_not(np.isclose(confounds_data.var(skipna=True), 0))


### PR DESCRIPTION
Finally got irritated enough to figure out why the confound order went nuts in the correlation plot. Using set, there are no order guarantees. We can get deduplication with `dict.from_keys()` instead, which produces a set-like dict with values all `None`. We can then just `list()` on the dict to get the keys back in the order they were initially passed.