### PR TITLE
fix: add option to bypass twopass in AFNI RobustAverage

### DIFF
--- a/niworkflows/interfaces/images.py
+++ b/niworkflows/interfaces/images.py
@@ -226,6 +226,9 @@ class _RobustAverageInputSpec(BaseInterfaceInputSpec):
         True, usedefault=True, desc="whether the output should be clipped below zero"
     )
     num_threads = traits.Int(desc="number of threads")
+    two_pass = traits.Bool(
+        True, usedefault=True, desc="whether two passes of correction is necessary"
+    )
 
 
 class _RobustAverageOutputSpec(TraitedSpec):
@@ -324,7 +327,7 @@ class RobustAverage(SimpleInterface):
             volreg = Volreg(
                 in_file=self._results["out_volumes"],
                 interp="Fourier",
-                args="-twopass",
+                args="-twopass" if self.inputs.two_pass else "",
                 zpad=4,
                 outputtype="NIFTI_GZ",
             )


### PR DESCRIPTION
Occasionally, the `-twopass` option in AFNI's 3dVolReg overshoots the mark, particularly when two volumes are already quite close in space (e.g. when pepolar "blip" images are acquired immediately after each other with the same slice package, but with the phase encoding direction reversed). 

[When using `RobustAverage` to merge two blip volumes ](https://github.com/nipreps/sdcflows/blob/0c497abbd9fa5b7a6f3f759d45ad7c94949b79be/sdcflows/workflows/fit/pepolar.py#L145), the second image is displaced >10mm on the second pass, giving a terrible average, while with only one pass the displacement is ~1mm. 

This PR gives the option to bypass the second pass and stick to just one. The default is `True` for backwards compatibility. WDYT?