### PR TITLE
MAINT: Mark future versions as post releases on the current major/minor/micro

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ exclude = [
 
 [tool.hatch.version]
 source = "vcs"
-raw-options = {version_scheme = "release-branch-semver" }
+raw-options = {version_scheme = "post-release"}
 
 [tool.hatch.build.hooks.vcs]
 version-file = "niworkflows/_version.py"


### PR DESCRIPTION
Right now we have released `1.7.9`, so future changes are being marked as `1.8.0.dev...`, breaking some of our pins.

This change avoids having to guess the next version and just marks as a post-release: `niworkflows-1.7.9.post53+g24f54712e`.

Alternatively, if there is a way to ensure `X.Y.9` -> `X.Y.10.dev...`, I'm fine with going that route.