### PR TITLE
MNT: Add PendingDeprecationWarning to nireports modules

### DIFF
--- a/niworkflows/interfaces/reportlets/__init__.py
+++ b/niworkflows/interfaces/reportlets/__init__.py
@@ -1,0 +1,7 @@
+import warnings
+
+msg = (
+    'Niworkflows will be deprecating reporting in favor of a standalone library "nireports".'
+)
+
+warnings.warn(msg, PendingDeprecationWarning)

--- a/niworkflows/viz/__init__.py
+++ b/niworkflows/viz/__init__.py
@@ -1,6 +1,14 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
+import warnings
+
 from .plots import plot_carpet
 from .utils import SVGNS
+
+msg = (
+    'Niworkflows will be deprecating visualizations in favor of a standalone library "nireports".'
+)
+
+warnings.warn(msg, PendingDeprecationWarning)
 
 __all__ = ["plot_carpet", "SVGNS"]


### PR DESCRIPTION
This is only to help our most vigilant of user, as it won't add noise unless Python Development Mode is enabled.