### PR TITLE
FIX: Save boldrefs as float32

### DIFF
--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -74,7 +74,7 @@ DEFAULT_DTYPES = defaultdict(
         ("mask", "uint8"),
         ("dseg", "int16"),
         ("probseg", "float32"),
-        ("boldref", "source"),
+        ("boldref", "float32"),
     ),
 )
 


### PR DESCRIPTION
Fixes nipreps/fmriprep#3055.

The goal of matching source dtypes for boldrefs was for straightforward comparisons, but because we say a file that is `int16` on-disk must be coerced to `int16`, we lose the scaling that makes that possible. I don't really want to try to handle all of the cases, as we already have a pretty baroque typing setup. I think the simplest thing is just to say that these are `float32`s.