### PR TITLE
ENH: add PET support to niworkflows

### DIFF
--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -277,7 +277,7 @@ class BIDSDataGrabber(SimpleInterface):
                 )
             )
 
-        for imtype in ["bold", "t2w", "flair", "fmap", "sbref", "roi"]:
+        for imtype in ["bold", "t2w", "flair", "fmap", "sbref", "roi", "pet"]:
             if not bids_dict[imtype]:
                 LOGGER.info(
                     'No "%s" images found for sub-%s', imtype, self.inputs.subject_id

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -225,6 +225,7 @@ class _BIDSDataGrabberOutputSpec(TraitedSpec):
     roi = OutputMultiObject(desc="output ROI images")
     t2w = OutputMultiObject(desc="output T2w images")
     flair = OutputMultiObject(desc="output FLAIR images")
+    pet = OutputMultiObject(desc="output PET images")
 
 
 class BIDSDataGrabber(SimpleInterface):

--- a/niworkflows/utils/bids.py
+++ b/niworkflows/utils/bids.py
@@ -233,6 +233,7 @@ def collect_data(
         "t2w": {"datatype": "anat", "suffix": "T2w", "part": ["mag", None]},
         "t1w": {"datatype": "anat", "suffix": "T1w", "part": ["mag", None]},
         "roi": {"datatype": "anat", "suffix": "roi"},
+        "pet": {"suffix": "pet"}
     }
     bids_filters = bids_filters or {}
     for acq, entities in bids_filters.items():


### PR DESCRIPTION
This PR adds PET support to the BIDS grabber in niworkflows, and addresses issue https://github.com/nipreps/niworkflows/issues/822#issue-1869149672 and mentioned here https://github.com/openneuropet/petdeface/pull/13