### PR TITLE
FIX:Compatibility with matplotlib 3.8.0

### DIFF
--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -887,8 +887,8 @@ def compcor_variance_plot(
         ax[m].set_yticks([])
         ax[m].set_yticklabels([])
         for tick in ax[m].xaxis.get_major_ticks():
-            tick.label.set_fontsize("x-small")
-            tick.label.set_rotation("vertical")
+            tick.label1.set_fontsize("x-small")
+            tick.label1.set_rotation("vertical")
         for side in ["top", "right", "left"]:
             ax[m].spines[side].set_color("none")
             ax[m].spines[side].set_visible(False)
@@ -981,9 +981,9 @@ def confounds_correlation_plot(
     ax0.tick_params(axis="both", which="both", width=0)
 
     for tick in ax0.xaxis.get_major_ticks():
-        tick.label.set_fontsize("small")
+        tick.label1.set_fontsize("small")
     for tick in ax0.yaxis.get_major_ticks():
-        tick.label.set_fontsize("small")
+        tick.label1.set_fontsize("small")
     sns.barplot(
         data=gscorr,
         x="index",
@@ -1000,10 +1000,10 @@ def confounds_correlation_plot(
     ax1.tick_params(axis="y", which="both", width=5, length=5)
 
     for tick in ax1.xaxis.get_major_ticks():
-        tick.label.set_fontsize("small")
-        tick.label.set_rotation("vertical")
+        tick.label1.set_fontsize("small")
+        tick.label1.set_rotation("vertical")
     for tick in ax1.yaxis.get_major_ticks():
-        tick.label.set_fontsize("small")
+        tick.label1.set_fontsize("small")
     for side in ["top", "right", "left"]:
         ax1.spines[side].set_color("none")
         ax1.spines[side].set_visible(False)

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -647,8 +647,8 @@ def plot_melodic_components(
         ax2.tick_params(axis="both", which="major", pad=0)
         sns.despine(left=True, bottom=True)
         for tick in ax2.xaxis.get_major_ticks():
-            tick.label.set_fontsize(6)
-            tick.label.set_color(color_time)
+            tick.label1.set_fontsize(6)
+            tick.label1.set_color(color_time)
 
         ax3.plot(
             f[0:],
@@ -661,8 +661,8 @@ def plot_melodic_components(
         ax3.autoscale_view("tight")
         ax3.tick_params(axis="both", which="major", pad=0)
         for tick in ax3.xaxis.get_major_ticks():
-            tick.label.set_fontsize(6)
-            tick.label.set_color(color_power)
+            tick.label1.set_fontsize(6)
+            tick.label1.set_color(color_power)
         sns.despine(left=True, bottom=True)
 
     plt.subplots_adjust(hspace=0.5)


### PR DESCRIPTION
The new release removes `Tick.label` and replaces it with `Tick.label1`. See https://github.com/matplotlib/matplotlib/pull/23463