### PR TITLE
FIX: Build config and CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,17 +423,17 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install build depends
-          command: python -m pip install "setuptools>=40.8.0" "pip>=19" "twine<2.0" docutils
+          name: Install pipx
+          command: python -m pip install pipx
       - run:
           name: Build and check
           command: |
-            python setup.py sdist
-            python -m twine check dist/*
+            pipx run build
+            pipx run twine check dist/*
       - run:
           name: Validate version
           command: |
-            THISVERSION=$( python get_version.py )
+            THISVERSION=$( python3 get_version.py )
             python -m pip install dist/*.tar.gz
             mkdir empty
             cd empty
@@ -447,27 +447,17 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install build depends
-          command: python -m pip install "setuptools>=40.8.0" "pip>=19" "twine<2.0" docutils
+          name: Install pipx
+          command: python -m pip install pipx
       - run:
           name: Build and check
           command: |
-            python setup.py check -r -s
-            python setup.py sdist
-            python -m twine check dist/*
-      - run:
-          name: Validate version
-          command: |
-            THISVERSION=$( python3 get_version.py )
-            python -m pip install dist/*.tar.gz
-            mkdir empty
-            cd empty
-            INSTALLED=$( python -c 'import niworkflows; print(niworkflows.__version__)' )
-            test "${CIRCLE_TAG:-$THISVERSION}" == "$INSTALLED"
+            pipx run build
+            pipx run twine check dist/*
       - run:
           name: Upload to PyPi
           command: |
-            python -m twine upload dist/*
+            pipx run twine upload dist/*
 
   deploy_docker:
     machine:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
 [build-system]
 # Keep synchronized with the minimum version to install in setup.py
-requires = ["setuptools >= 30.4.0", "wheel"]
+requires = ["setuptools >= 40.8.0", "versioneer"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ classifiers =
     Programming Language :: Python :: 3.9
 description = NeuroImaging Workflows provides processing tools for magnetic resonance images of the brain.
 license = 3-clause BSD
-license_file = LICENSE
+license_files = LICENSE
 long_description = file:README.rst
 long_description_content_type = text/x-rst; charset=UTF-8
 project_urls =

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,10 @@ from setuptools import setup
 import versioneer
 
 # Use setup_requires to let setuptools complain if it's too old for a feature we need
-# 30.3.0 allows us to put most metadata in setup.cfg
-# 30.4.0 gives us options.packages.find
 # 40.8.0 includes license_file, reducing MANIFEST.in requirements
 #
-# To install, 30.4.0 is enough, but if we're building an sdist, require 40.8.0
-# This imposes a stricter rule on the maintainer than the user
 # Keep the installation version synchronized with pyproject.toml
-SETUP_REQUIRES = [f"setuptools >= {'40.8.0' if 'sdist' in sys.argv else '30.4.0'}"]
+SETUP_REQUIRES = ["setuptools >= 40.8.0"]
 
 # This enables setuptools to install wheel on-the-fly
 if "bdist_wheel" in sys.argv:


### PR DESCRIPTION
Latest PyPI upload for the LTS branch failed because twine was incompatible with urllib3 in the build environment.

This PR switches to `pipx`, which is less susceptible to incompatible environments, and uses it to run `build` and `twine`, simplifying things significantly.

During testing, got an error over our use of `license_file` instead of `license_files`, so I updated that and the minimum setuptools versions. Added `build-backend` by default, which then led to needing to add versioneer to the build requires.

Current tests use all of the changes except deploy, so if checks are green, this should be safe to merge.