### PR TITLE
STY: Assorted refurb suggestions

### DIFF
--- a/docs/sphinxext/github.py
+++ b/docs/sphinxext/github.py
@@ -152,4 +152,3 @@ def setup(app):
     app.add_role('ghuser', ghuser_role)
     app.add_role('ghcommit', ghcommit_role)
     app.add_config_value('github_project_url', None, 'env')
-    return

--- a/niworkflows/tests/conftest.py
+++ b/niworkflows/tests/conftest.py
@@ -23,7 +23,7 @@
 """ py.test configuration file """
 import os
 from pathlib import Path
-from datetime import datetime as dt
+import datetime as dt
 import pytest
 from templateflow.api import get as get_template
 from niworkflows.testing import test_data_env, data_env_canary
@@ -34,7 +34,7 @@ datadir = load_test_data()
 
 def _run_interface_mock(objekt, runtime):
     runtime.returncode = 0
-    runtime.endTime = dt.isoformat(dt.utcnow())
+    runtime.endTime = dt.datetime.isoformat(dt.datetime.now(dt.timezone.utc))
 
     objekt._out_report = os.path.abspath(objekt.inputs.out_report)
     objekt._post_run_hook(runtime)

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -212,10 +212,7 @@ def _3d_in_file(in_file):
 
     in_file = filemanip.filename_to_list(in_file)[0]
 
-    try:
-        in_file = nb.load(in_file)
-    except AttributeError:
-        in_file = in_file
+    in_file = nb.load(in_file)
 
     if len(in_file.shape) == 3:
         return in_file

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -586,9 +586,10 @@ def plot_melodic_components(
     else:
         mask_img = nb.load(report_mask)
 
-    mask_sl = []
-    for j in range(3):
-        mask_sl.append(transform_to_2d(mask_img.get_fdata(), j))
+    mask_sl = [
+        transform_to_2d(mask_img.get_fdata(), j)
+        for j in range(3)
+    ]
 
     timeseries = np.loadtxt(os.path.join(melodic_dir, "melodic_mix"))
     power = np.loadtxt(os.path.join(melodic_dir, "melodic_FTmix"))


### PR DESCRIPTION
* remove no-ops (`return` at end of function and `x = x`)
* use list comprehensions
* `utcnow()` → `now(tz=timezone.utc)`
   From https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow:
  > **Warning:** Because naive `datetime` objects are treated by many `datetime` methods as local times, it is preferred to use aware datetimes to represent times in UTC. As such, the recommended way to create an object representing the current time in UTC is by calling `datetime.now(timezone.utc)`.
  > 
  > _Deprecated since version 3.12:_ Use [`datetime.now()`](https://docs.python.org/3/library/datetime.html#datetime.datetime.now) with [`UTC`](https://docs.python.org/3/library/datetime.html#datetime.UTC) instead.