### PR TITLE
Add `ignore_initial_volumes` param to `ConfoundsCorrelationPlot`

### DIFF
--- a/niworkflows/interfaces/plotting.py
+++ b/niworkflows/interfaces/plotting.py
@@ -195,6 +195,12 @@ class _ConfoundsCorrelationPlotInputSpec(BaseInterfaceInputSpec):
         "correlation with `reference_column` will be "
         "selected.",
     )
+    ignore_initial_volumes = traits.Int(
+        0,
+        usedefault=True,
+        desc="Number of non-steady-state volumes at the beginning of the scan "
+        "to ignore.",
+    )
 
 
 class _ConfoundsCorrelationPlotOutputSpec(TraitedSpec):
@@ -223,6 +229,7 @@ class ConfoundsCorrelationPlot(SimpleInterface):
             max_dim=self.inputs.max_dim,
             output_file=self._results["out_file"],
             reference=self.inputs.reference_column,
+            ignore_initial_volumes=self.inputs.ignore_initial_volumes,
         )
         return runtime
 

--- a/niworkflows/tests/test_confounds.py
+++ b/niworkflows/tests/test_confounds.py
@@ -178,7 +178,7 @@ def test_ConfoundsCorrelationPlot():
     """confounds correlation report test"""
     confounds_file = os.path.join(datadir, "confounds_test.tsv")
     cc_rpt = ConfoundsCorrelationPlot(
-        confounds_file=confounds_file, reference_column="a",
+        confounds_file=confounds_file, reference_column="a", ignore_initial_volumes=1,
     )
     _smoke_test_report(cc_rpt, "confounds_correlation.svg")
 
@@ -187,6 +187,9 @@ def test_ConfoundsCorrelationPlotColumns():
     """confounds correlation report test"""
     confounds_file = os.path.join(datadir, "confounds_test.tsv")
     cc_rpt = ConfoundsCorrelationPlot(
-        confounds_file=confounds_file, reference_column="a", columns=["b", "d", "f"],
+        confounds_file=confounds_file,
+        reference_column="a",
+        columns=["b", "d", "f"],
+        ignore_initial_volumes=0,
     )
     _smoke_test_report(cc_rpt, "confounds_correlation_cols.svg")

--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -861,6 +861,7 @@ def confounds_correlation_plot(
     max_dim=20,
     output_file=None,
     reference="global_signal",
+    ignore_initial_volumes=0,
 ):
     """
     Generate a bar plot with the correlation of confounds.
@@ -889,6 +890,8 @@ def confounds_correlation_plot(
         of each confound regressor with a reference column. By default, this
         is the global signal (so that collinearities with the global signal
         can readily be assessed).
+    ignore_initial_volumes : :obj:`int`
+        Number of non-steady-state volumes at the beginning of the scan to ignore.
 
     Returns
     -------


### PR DESCRIPTION
Related to https://github.com/nipreps/fmriprep/issues/2614. Once this is merged and there's a new release, I will open a PR to fMRIPrep.

Changes proposed:

- Add an `ignore_initial_volumes` parameter to the `ConfoundsCorrelationPlot` interface.
- Add an `ignore_initial_volumes` parameter to the `confounds_correlation_plot` function.
- Use the new parameter in related smoke tests.