### PR TITLE
Correctly use `ignore_initial_volumes` in `ConfoundsCorrelationPlot`

### DIFF
--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -910,7 +910,8 @@ def confounds_correlation_plot(
         confounds_data = confounds_data[list(columns)]
 
     confounds_data = confounds_data.loc[
-        :, np.logical_not(np.isclose(confounds_data.var(skipna=True), 0))
+        ignore_initial_volumes:,
+        np.logical_not(np.isclose(confounds_data.var(skipna=True), 0)),
     ]
     corr = confounds_data.corr()
 


### PR DESCRIPTION
Fixes a bug I missed in #843, where the new parameter wasn't actually used.