### PR TITLE
ENH: Allow alternative `extensions` when creating a BIDS skeleton

### DIFF
--- a/niworkflows/utils/testing.py
+++ b/niworkflows/utils/testing.py
@@ -74,14 +74,15 @@ def generate_bids_skeleton(target_path, bids_config):
 
                 for bids_file in files:
                     metadata = bids_file.pop("metadata", None)
+                    extension = bids_file.pop("extension", ".nii.gz")
                     suffix = bids_file.pop("suffix")
                     entities = combine_entities(**bids_file)
-                    nii_file = modality_path / f"{bids_prefix}{entities}_{suffix}.nii.gz"
-                    nii_file.touch()
+                    out_file = modality_path / f"{bids_prefix}{entities}_{suffix}{extension}"
+                    out_file.touch()
 
                     if metadata is not None:
-                        nii_metadata = nii_file.parent / nii_file.name.replace("nii.gz", "json")
-                        to_json(nii_metadata, metadata)
+                        out_metadata = out_file.parent / out_file.name.replace(extension, ".json")
+                        to_json(out_metadata, metadata)
 
     return _bids_dict
 

--- a/niworkflows/utils/testing.py
+++ b/niworkflows/utils/testing.py
@@ -77,11 +77,11 @@ def generate_bids_skeleton(target_path, bids_config):
                     extension = bids_file.pop("extension", ".nii.gz")
                     suffix = bids_file.pop("suffix")
                     entities = combine_entities(**bids_file)
-                    out_file = modality_path / f"{bids_prefix}{entities}_{suffix}{extension}"
-                    out_file.touch()
+                    data_file = modality_path / f"{bids_prefix}{entities}_{suffix}{extension}"
+                    data_file.touch()
 
                     if metadata is not None:
-                        out_metadata = out_file.parent / out_file.name.replace(extension, ".json")
+                        out_metadata = data_file.parent / data_file.name.replace(extension, ".json")
                         to_json(out_metadata, metadata)
 
     return _bids_dict

--- a/niworkflows/utils/testing.py
+++ b/niworkflows/utils/testing.py
@@ -81,7 +81,9 @@ def generate_bids_skeleton(target_path, bids_config):
                     data_file.touch()
 
                     if metadata is not None:
-                        out_metadata = data_file.parent / data_file.name.replace(extension, ".json")
+                        out_metadata = data_file.parent / data_file.name.replace(
+                            extension, ".json"
+                        )
                         to_json(out_metadata, metadata)
 
     return _bids_dict

--- a/niworkflows/utils/tests/test_bids_skeleton.py
+++ b/niworkflows/utils/tests/test_bids_skeleton.py
@@ -1,6 +1,8 @@
 import pytest
 from bids import BIDSLayout
 
+import json
+
 from ..testing import generate_bids_skeleton
 
 
@@ -107,12 +109,31 @@ bids_dir_session_less = {
     "04": "*",
 }
 
+bids_dir_deriv = {
+    "dataset_description": {
+        "Name": "derivs",
+        "DatasetType": "derivative",
+        "BIDSVersion": "1.9.0",
+        "GeneratedBy": [
+            {"Name": "Niworkflows"}
+        ]
+    },
+    "01": {
+        "anat": [
+            {"suffix": "white", "hemi": "L", "extension": ".surf.gii"},
+            {"suffix": "white", "hemi": "R", "extension": ".surf.gii"},
+            {"suffix": "xfm", "to": "MNI152NLin2009cAsym", "from": "T1w", "extension": ".h5"}
+        ]
+    }
+}
+
 
 @pytest.mark.parametrize(
     "test_id,json_layout,n_files,n_subjects,n_sessions",
     [
         ('sessions', bids_dir_sessions, 31, 3, 2),
         ('nosession', bids_dir_session_less, 25, 4, 0),
+        ('derivatives', bids_dir_deriv, 4, 1, 0)
     ],
 )
 def test_generate_bids_skeleton(tmp_path, test_id, json_layout, n_files, n_subjects, n_sessions):
@@ -120,16 +141,25 @@ def test_generate_bids_skeleton(tmp_path, test_id, json_layout, n_files, n_subje
     generate_bids_skeleton(root, json_layout)
     datadesc = root / "dataset_description.json"
     assert datadesc.exists()
-    assert "BIDSVersion" in datadesc.read_text()
+    desc = json.loads(datadesc.read_text())
+    assert "BIDSVersion" in desc
+    if test_id == 'derivatives':
+        assert desc["DatasetType"] == "derivative"
 
     assert len([x for x in root.glob("**/*") if x.is_file()]) == n_files
 
     # ensure layout is valid
-    layout = BIDSLayout(root)
+    layout = BIDSLayout(root, validate=False)
     assert len(layout.get_subjects()) == n_subjects
     assert len(layout.get_sessions()) == n_sessions
 
-    anat = layout.get(suffix="T1w", extension="nii.gz")[0]
-    bold = layout.get(suffix="bold", extension="nii.gz")[0]
-    assert anat.get_metadata()
-    assert bold.get_metadata()
+    if test_id != 'derivatives':
+        anat = layout.get(suffix="T1w", extension=".nii.gz")[0]
+        bold = layout.get(suffix="bold", extension=".nii.gz")[0]
+        assert anat.get_metadata()
+        assert bold.get_metadata()
+    else:
+        white = layout.get(suffix="white")
+        assert len(white) == 2
+        xfm = layout.get(suffix="xfm")[0]
+        assert xfm


### PR DESCRIPTION
This allows creating non-`nii.gz` files through `generate_bids_skeleton`. If no extension is provided, `.nii.gz` will still be used as the default.