### PR TITLE
STY: Apply ruff/flake8-implicit-str-concat rule ISC001

### DIFF
--- a/niworkflows/interfaces/nibabel.py
+++ b/niworkflows/interfaces/nibabel.py
@@ -234,7 +234,7 @@ class MergeSeries(SimpleInterface):
                 continue
             else:
                 raise ValueError(
-                    "Input image has an incorrect number of dimensions" f" ({ndim})."
+                    f"Input image has an incorrect number of dimensions ({ndim})."
                 )
 
         img_4d = nb.concat_images(

--- a/niworkflows/viz/utils.py
+++ b/niworkflows/viz/utils.py
@@ -566,7 +566,7 @@ def plot_melodic_components(
                 tr = tr / 1000000.0
             elif units[-1] != "sec":
                 NIWORKFLOWS_LOG.warning(
-                    "Unknown repetition time units " "specified - assuming seconds"
+                    "Unknown repetition time units specified - assuming seconds"
                 )
         else:
             NIWORKFLOWS_LOG.warning(


### PR DESCRIPTION
	ISC001 Implicitly concatenated string literals on one line

This rule is currently disabled because it conflicts with the formatter: https://github.com/astral-sh/ruff/issues/8272