### PR TITLE
Check 2D spaces against list from templateflow

### DIFF
--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -119,6 +119,16 @@ class Reference:
     >>> Reference('MNIPediatricAsym', {'cohort': 1}).standard
     True
 
+    >>> # Check dim property
+    >>> Reference('func').dim
+    3
+    >>> Reference('MNI152NLin6Asym').dim
+    3
+    >>> Reference('fsnative').dim
+    2
+    >>> Reference('onavg').dim
+    2
+
     >>> # Equality/inequality checks
     >>> Reference('func') == Reference('func')
     True

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -42,6 +42,8 @@ NONSTANDARD_REFERENCES = [
 ]
 """List of supported nonstandard reference spaces."""
 
+NONSTANDARD_2D_REFERENCES = ["fsnative"]
+"""List of supported nonstandard 2D reference spaces."""
 
 FSAVERAGE_DENSITY = {
     "fsaverage3": "642",
@@ -138,6 +140,7 @@ class Reference:
     """
 
     _standard_spaces = tuple(_tfapi.templates())
+    _spaces_2d = tuple(_tfapi.templates(suffix="sphere"))
 
     space = attr.ib(default=None, type=str)
     """Name designating this space."""
@@ -165,7 +168,7 @@ class Reference:
                 spec["den"] = FSAVERAGE_DENSITY[space]
                 object.__setattr__(self, "spec", spec)
 
-        if self.space.startswith("fs"):
+        if (self.space in self._spaces_2d) or (self.space in NONSTANDARD_2D_REFERENCES):
             object.__setattr__(self, "dim", 2)
 
         if self.space in self._standard_spaces:


### PR DESCRIPTION
Closes #882.

Changes proposed:

- To determine dimensionality of a reference space (i.e., surface vs. volume), build a list of 2D standard spaces from templateflow by searching for spaces with a `sphere` file. I also added a constant list of 2D non-standard spaces to check against, although it's currently just `fsnative`.
    - The old way looked at the start of the space's name and checked if it began with `fs`, which works for `fsnative`, `fsaverage`, and `fsLR`, but not for `onavg`, `dhcpSym`, or `dhcpAsym`.