### PR TITLE
STY: Apply ruff/flake8-comprehensions preview rule C409

### DIFF
--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -647,9 +647,7 @@ class PrepareDerivative(SimpleInterface):
 
                 if self.inputs.check_hdr:
                     hdr = nii.header
-                    curr_units = tuple(
-                        [None if u == 'unknown' else u for u in hdr.get_xyzt_units()]
-                    )
+                    curr_units = tuple(None if u == 'unknown' else u for u in hdr.get_xyzt_units())
                     curr_codes = (int(hdr['qform_code']), int(hdr['sform_code']))
 
                     # Default to mm, use sec if data type is bold
@@ -1164,9 +1162,7 @@ space-MNI152NLin6Asym_desc-preproc_bold.json'
 
                 if self.inputs.check_hdr:
                     hdr = nii.header
-                    curr_units = tuple(
-                        [None if u == 'unknown' else u for u in hdr.get_xyzt_units()]
-                    )
+                    curr_units = tuple(None if u == 'unknown' else u for u in hdr.get_xyzt_units())
                     curr_codes = (int(hdr['qform_code']), int(hdr['sform_code']))
 
                     # Default to mm, use sec if data type is bold

--- a/niworkflows/reports/core.py
+++ b/niworkflows/reports/core.py
@@ -454,9 +454,9 @@ class Report:
             for bids_file in layout.get()
         }
         # remove the all None member if it exists
-        none_member = tuple([None for k in orderings])
+        none_member = tuple(None for k in orderings)
         if none_member in all_value_combos:
-            all_value_combos.remove(tuple([None for k in orderings]))
+            all_value_combos.remove(tuple(None for k in orderings))
         # see what values exist for each entity
         unique_values = [
             {value[idx] for value in all_value_combos} for idx in range(len(orderings))


### PR DESCRIPTION
C409 Unnecessary list comprehension passed to `tuple()` (rewrite as a generator)