### PR TITLE
ENH: Parse kwargs to allow no T1w

### DIFF
--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -253,18 +253,11 @@ class BIDSDataGrabber(SimpleInterface):
     >>> bids_src.inputs.subject_data = bids_collect_data(
     ...     str(datadir / 'ds114'), '01', bids_validate=False)[0]
     >>> bids_src.inputs.subject_id = '01'
-    >>> bids_src._require_t1w
-    True
-    >>> bids_src._require_funcs
-    True
     >>> res = bids_src.run()
     >>> res.outputs.t1w  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
     ['.../ds114/sub-01/ses-retest/anat/sub-01_ses-retest_T1w.nii.gz',
      '.../ds114/sub-01/ses-test/anat/sub-01_ses-test_T1w.nii.gz']
 
-    >>> bids_src = BIDSDataGrabber(require_t1w=False)
-    >>> bids_src._require_t1w
-    False
     """
 
     input_spec = _BIDSDataGrabberInputSpec

--- a/niworkflows/interfaces/bids.py
+++ b/niworkflows/interfaces/bids.py
@@ -253,11 +253,18 @@ class BIDSDataGrabber(SimpleInterface):
     >>> bids_src.inputs.subject_data = bids_collect_data(
     ...     str(datadir / 'ds114'), '01', bids_validate=False)[0]
     >>> bids_src.inputs.subject_id = '01'
+    >>> bids_src._require_t1w
+    True
+    >>> bids_src._require_funcs
+    True
     >>> res = bids_src.run()
     >>> res.outputs.t1w  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
     ['.../ds114/sub-01/ses-retest/anat/sub-01_ses-retest_T1w.nii.gz',
      '.../ds114/sub-01/ses-test/anat/sub-01_ses-test_T1w.nii.gz']
 
+    >>> bids_src = BIDSDataGrabber(require_t1w=False)
+    >>> bids_src._require_t1w
+    False
     """
 
     input_spec = _BIDSDataGrabberInputSpec
@@ -265,12 +272,13 @@ class BIDSDataGrabber(SimpleInterface):
     _require_funcs = True
 
     def __init__(self, *args, **kwargs):
-        anat_only = kwargs.pop('anat_only')
+        anat_only = kwargs.pop('anat_only', None)
         anat_derivatives = kwargs.pop('anat_derivatives', None)
+        require_t1w = kwargs.pop('require_t1w', True)
         super().__init__(*args, **kwargs)
         if anat_only is not None:
             self._require_funcs = not anat_only
-        self._require_t1w = anat_derivatives is None
+        self._require_t1w = require_t1w and anat_derivatives is None
 
     def _run_interface(self, runtime):
         bids_dict = self.inputs.subject_data

--- a/niworkflows/interfaces/tests/test_bids.py
+++ b/niworkflows/interfaces/tests/test_bids.py
@@ -793,3 +793,16 @@ def test_fsdir_min_version(tmp_path, min_version):
         assert not patched_subject_dir.exists()
     else:
         assert patched_subject_dir.exists()
+
+
+def test_BIDSDataGrabber():
+    x = bintfs.BIDSDataGrabber(anat_only=True)
+    assert x._require_t1w is True
+    assert x._require_funcs is False
+
+    x = bintfs.BIDSDataGrabber(anat_only=False, require_t1w=False)
+    assert x._require_t1w is False
+    assert x._require_funcs is True
+
+    x = bintfs.BIDSDataGrabber(anat_derivatives='derivatives')
+    assert x._require_t1w is False


### PR DESCRIPTION
This came up in https://github.com/nipreps/nibabies/issues/411

Also, adds a default to the expected kwarg `anat_only` to allow bare initialization