### PR TITLE
fix(brain_extraction_wf): Pass inu_n4 to atropos_wf

### DIFF
--- a/niworkflows/anat/ants.py
+++ b/niworkflows/anat/ants.py
@@ -476,7 +476,7 @@ def init_brain_extraction_wf(
         ])
         wf.connect([
             (inputnode, atropos_wf, [("in_files", "inputnode.in_files")]),
-            (inu_n4_final, atropos_wf, [("output_image", "inputnode.in_corrected")]),
+            (inu_n4, atropos_wf, [("output_image", "inputnode.in_corrected")]),
             (thr_brainmask, atropos_wf, [("output_image", "inputnode.in_mask")]),
             (atropos_wf, outputnode, [
                 ("outputnode.out_file", "out_file"),


### PR DESCRIPTION
antsBrainExtraction.sh passes the original N4 corrected image to Atropos, where we have been running a masked N4 before Atropos. We have examples where this difference leads to failures that do not occur in the original ANTs workflow. Further, if we do run Atropos, then this result is discarded and N4 is run using a white-matter mask.

This patch therefore simply passes the original N4 image to the Atropos workflow, but otherwise leaves the workflow unchanged.

This targets the `maint/1.10.x` branch for inclusion in a patch to fmriprep 24.0.1. Merging depends on an assessment that #929 does not excessively impact derivatives. This PR in any event does provide for testing.