### PR TITLE
rel: 1.14.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
 
   get_data:
     docker:
-      - image: quay.io/condaforge/miniforge3:24.9.0-0
+      - image: quay.io/condaforge/miniforge3:latest
     working_directory: /tmp/data
     environment:
       - TEMPLATEFLOW_HOME: /tmp/templateflow

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,17 @@
+1.14.0 (May 07, 2025)
+=====================
+New feature release in the 1.14.x series.
+
+This release introduces a tagging system for workflows,
+which has the goal of allowing portions of workflows to be spliced.
+Splicing removes the existing portion of the workflow and replaces it
+with a workflow that has the same input/output connections.
+
+This is an experimental feature, and is subject to change with no deprecation period.
+
+* FIX: Allow passing arguments through tag decorator (#939)
+* ENH: Workflow splicer module (#938)
+
 1.13.0 (March 20, 2025)
 =======================
 New feature release in the 1.13.x series.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ exclude = [".git_archival.txt"]  # No longer needed in sdist
 packages = ["niworkflows"]
 exclude = [
     "niworkflows/data/tests/work",  # Large test data directory
+    "niworkflows/tests/data",  # Large test data directory
 ]
 
 ##  The following two sections configure setuptools_scm in the hatch way

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Image Recognition",
 ]
 dependencies = [


### PR DESCRIPTION
@mgxd Is this ready for an experimental release? I'm saying in the release notes that we are not providing any API guarantees, but this will let us release an smriprep with tags right away.

This also drops the wheel size from ~60MB to <1MB by excluding test data.