### PR TITLE
chore: Accept main where master is used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
             - build-v1--{{ .Revision }}
             - build-v1-{{ .Branch }}-
             - build-v1-master-
+            - build-v1-main-
             - build-v1-
           paths:
             - /tmp/docker
@@ -141,6 +142,7 @@ jobs:
           keys:
             - data-v3-{{ .Branch }}-
             - data-v3-master-
+            - data-v3-main-
             - data-v3-
       - run:
           name: Get test data from ds000003
@@ -211,6 +213,7 @@ jobs:
           keys:
             - data-v3-{{ .Branch }}-
             - data-v3-master-
+            - data-v3-main-
 
       - run:
           name: Run unit tests

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,9 +3,9 @@ name: Codespell
 
 on:
   push:
-    branches: [master]
+    branches: [master, main]
   pull_request:
-    branches: [master]
+    branches: [master, main]
 
 jobs:
   codespell:

--- a/.github/workflows/docs-build-pr.yml
+++ b/.github/workflows/docs-build-pr.yml
@@ -3,7 +3,7 @@ name: Build docs
 
 on:
   pull_request:
-    branches: [ master, 'maint/*' ]
+    branches: [ master, main, 'maint/*' ]
 
 jobs:
   build:

--- a/.github/workflows/docs-build-update.yml
+++ b/.github/workflows/docs-build-update.yml
@@ -3,7 +3,7 @@ name: Build & update docs
 
 on:
   push:
-    branches: [ 'doc/*', 'docs/*', master, "maint/*" ]
+    branches: [ 'doc/*', 'docs/*', master, main, "maint/*" ]
     tags: [ '*' ]
 
 jobs:
@@ -67,18 +67,18 @@ jobs:
         git commit -m "rel(${CURBRANCH}): Update docs of ${MAJOR_MINOR} series" || true
         git push
 
-    - name: Push "master" docs to gh-pages after a PR is merged
-      if: github.ref == 'refs/heads/master'
+    - name: Push "main" docs to gh-pages after a PR is merged
+      if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
       run: |
-        if [[ "${CURBRANCH}" != "master" ]]; then
+        if [[ "${CURBRANCH}" != "master" -a "${CURBRANCH}" != "main" ]]; then
             echo "$CURBRANCH is not the default development branch"
             exit 1
         fi
         git checkout -b gh-pages origin/gh-pages
-        git rm -r master/ || true
+        git rm -r ${CURBRANCH}/ || true
         # It is fundamental that the directory does not exist at all.
-        rm -rf master
-        cp -r $HOME/docs/$CURBRANCH $PWD/master
-        git add master
-        git commit -am "docs(master): Update docs of development line" || true
+        rm -rf ${CURBRANCH}
+        cp -r $HOME/docs/$CURBRANCH $PWD/${CURBRANCH}
+        git add ${CURBRANCH}
+        git commit -am "docs(${CURBRANCH}): Update docs of development line" || true
         git push

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -5,7 +5,7 @@ on:
     branches: [ '**' ]
     tags: [ '*' ]
   pull_request:
-    branches: [ master, 'maint/*' ]
+    branches: [ master, main, 'maint/*' ]
   schedule:
     - cron: '0 0 * * *'
 

--- a/docs/_static/js/version-switch.js
+++ b/docs/_static/js/version-switch.js
@@ -1,17 +1,17 @@
 $(document).ready(function() {
-    var pathname = window.location.pathname;
-    var cur_ver = $("#version-slug").text().replace(/^[\n\s]+|[\n\s]+$/g, '')
-    var major_minor = "master";
+    const pathname = window.location.pathname;
+    const cur_ver = $("#version-slug").text().replace(/^[\n\s]+|[\n\s]+$/g, '')
+    let major_minor = "master";
     if ( cur_ver.lastIndexOf(" (dev)") == -1 ) {
         major_minor = `${cur_ver.split('.')[0]}.${cur_ver.split('.')[1]}`
     }
-    var relpath = pathname.substring(pathname.lastIndexOf(major_minor)).replace(/\/$/, '');
-    var levels = relpath.split("/").length - 1
+    let relpath = pathname.substring(pathname.lastIndexOf(major_minor)).replace(/\/$/, '');
+    let levels = relpath.split("/").length - 1
     if ( levels == 0 ) {
         levels = 1
         relpath += "/"
     }
-    var versions_file = "../".repeat(levels) + "versions.json"
+    const versions_file = "../".repeat(levels) + "versions.json"
     relpath = "../".repeat(levels) + relpath
     relpath = relpath.replace("//", "/")
     console.log(`relpath="${relpath}", cur_ver="${cur_ver}"`)
@@ -20,17 +20,17 @@ $(document).ready(function() {
         $("#version-slug").remove();  // Unnecessary if JSON was downloaded
 
         $.each(data["tags"].reverse(), function( i, val ) {
-            var new_path = relpath.replace(major_minor, val)
-            var item = `<li class="toctree-l2"><a class="reference internal" href="${new_path}">${val}</a></li>`
+            const new_path = relpath.replace(major_minor, val)
+            let item = `<li class="toctree-l2"><a class="reference internal" href="${new_path}">${val}</a></li>`
             if ( i == 0 ) {
                 item = `<li class="toctree-l2"><a class="reference internal" href="${new_path}">${val} (Latest Release)</a></li>`
             }
             $("#v-tags").append(item)
         });
         $.each(data["heads"].reverse(), function( i, val ) {
-            var new_path = relpath.replace(major_minor, val)
-            var item = `<li class="toctree-l2"><a class="reference internal" href="${new_path}">${val}</a></li>`
-            if ( val == "master" ) {
+            const new_path = relpath.replace(major_minor, val)
+            let item = `<li class="toctree-l2"><a class="reference internal" href="${new_path}">${val}</a></li>`
+            if ( ["master", "main"].includes(val) ) {
                 item = `<li class="toctree-l2"><a class="reference internal" href="${new_path}">${val} (Development)</a></li>`
             }
             $("#v-tags").append(item)


### PR DESCRIPTION
This will simplify the transition process if/when we change the dev branch name to `main`.

Only thing remaining would be the `    let major_minor = "master";` in the doc version switcher.