### PR TITLE
chore: Fix coverage config for parallel runners

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,7 @@ junit_family = "xunit2"
 
 [tool.coverage.run]
 branch = true
+parallel = true
 omit = [
     "*/_version.py",
 ]


### PR DESCRIPTION
Actions are failing intermittently with https://github.com/nedbat/coveragepy/issues/883.