### PR TITLE
FIX: Do not allow filters to overwrite participant / session

### DIFF
--- a/niworkflows/utils/bids.py
+++ b/niworkflows/utils/bids.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 from bids import BIDSLayout
 from bids.layout import Query
+from bids.utils import listify
 from packaging.version import Version
 
 DEFAULT_BIDS_QUERIES = {
@@ -256,7 +257,7 @@ def collect_data(
     for acq, entities in bids_filters.items():
         # BIDS filters will not be able to override subject / session entities
         for entity, param in reserved_entities:
-            if entity in entities and param != entities[entity]:
+            if entity in entities and listify(param) != listify(entities[entity]):
                 raise ValueError(
                     f'Conflicting entities for "{entity}" found: {entities[entity]} // {param}'
                 )

--- a/niworkflows/utils/bids.py
+++ b/niworkflows/utils/bids.py
@@ -22,6 +22,7 @@
 #
 """Helpers for handling BIDS-like neuroimaging structures."""
 
+import copy
 import json
 import re
 import warnings
@@ -243,6 +244,9 @@ def collect_data(
     else:
         layout = BIDSLayout(str(bids_dir), validate=bids_validate)
 
+    if not queries:
+        queries = copy.deepcopy(DEFAULT_BIDS_QUERIES)
+
     layout_get_kwargs = {
         'return_type': 'file',
         'subject': participant_label,
@@ -252,7 +256,6 @@ def collect_data(
 
     reserved_entities = [('subject', participant_label), ('session', session_id)]
 
-    queries = queries or DEFAULT_BIDS_QUERIES
     bids_filters = bids_filters or {}
     for acq, entities in bids_filters.items():
         # BIDS filters will not be able to override subject / session entities


### PR DESCRIPTION
This PR introduces an error on mismatch between `subject`/`session` entities and bids_filters.