### PR TITLE
MNT: no need to re-run `ruff check` after `ruff format`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,3 @@ repos:
         args: [ --fix ]
       - name: ruff format
         id: ruff-format
-      - name: fix implicit string concatenation
-        id: ruff
-        args: [ --select, ISC001, --fix ]


### PR DESCRIPTION
Running `ruff check` then `ruff format` should always do the right thing.

No need to rerun `ruff check` specifically for `ISC001`.