### PR TITLE
fix: Address failures from nilearn/matplotlib

### DIFF
--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -206,6 +206,8 @@ def plot_carpet(
     if detrend:
         from nilearn.signal import clean
 
+        if tr is not None:
+            tr = float(tr)
         data = clean(data.T, t_r=tr, filter=False).T
 
     # We want all subplots to have the same dynamic range

--- a/niworkflows/viz/plots.py
+++ b/niworkflows/viz/plots.py
@@ -1092,6 +1092,7 @@ def cifti_surfaces_plot(
                 vmin=mn,
                 vmax=mx,
                 axes=ax,
+                colorbar=False,
                 **hemi_kwargs,
                 **kwargs,
             )


### PR DESCRIPTION
* b660fa76d7ef05a529ee1ed483be3095fd517bb9 addresses https://github.com/nilearn/nilearn/issues/5545
* 8653562b39c3da2f0ab9c7779e6d999f3275a4f0 addresses https://github.com/matplotlib/matplotlib/issues/25538 or similar, which seems to be related to `plot_surf` adding its own color bars and then us adding another one. Disabling either fixes the problem, but there's no need to have a colorbar per subplot.