### PR TITLE
Replace 'ref' entity with 'label' entity according to BIDS specification

### DIFF
--- a/niworkflows/data/nipreps.json
+++ b/niworkflows/data/nipreps.json
@@ -50,10 +50,6 @@
       "pattern": "[_/\\\\]+pvc-([a-zA-Z0-9+]+)"
     },
     {
-      "name": "ref",
-      "pattern": "[_/\\\\]+ref-([a-zA-Z0-9+]+)"
-    },
-    {
       "name": "modality",
       "pattern": "[_/\\\\]+mod-([a-zA-Z0-9+]+)"
     },


### PR DESCRIPTION
This PR updates the nipreps.json file to align with the PET-BIDS derivatives specification. Specifically, it removes the previously introduced 'ref' entity, and instead uses the 'label' entity in accordance with the BIDS specification.