### PR TITLE
FIX: Make confound expansion column order deterministic

### DIFF
--- a/niworkflows/interfaces/confounds.py
+++ b/niworkflows/interfaces/confounds.py
@@ -499,7 +499,7 @@ def temporal_derivatives(order, variables, data):
     if 0 in order:
         data_deriv[0] = data[variables]
         variables_deriv[0] = variables
-        order = set(order) - {0}
+        order = sorted(set(order) - {0})
     for o in order:
         variables_deriv[o] = [f'{v}_derivative{o}' for v in variables]
         data_deriv[o] = np.tile(np.nan, data[variables].shape)
@@ -542,7 +542,7 @@ def exponential_terms(order, variables, data):
     if 1 in order:
         data_exp[1] = data[variables]
         variables_exp[1] = variables
-        order = set(order) - {1}
+        order = sorted(set(order) - {1})
     for o in order:
         variables_exp[o] = [f'{v}_power{o}' for v in variables]
         data_exp[o] = data[variables] ** o
@@ -690,7 +690,8 @@ def _expand_shorthand(model_formula, variables):
     model_formula = model_formula.replace('spikes', spikes)
 
     formula_variables = _get_variables_from_formula(model_formula)
-    others = ' + '.join(set(variables) - set(formula_variables))
+    formula_set = set(formula_variables)
+    others = ' + '.join(v for v in variables if v not in formula_set)
     model_formula = model_formula.replace('others', others)
     return model_formula
 
@@ -787,7 +788,7 @@ def parse_formula(model_formula, parent_data, unscramble=False):
             )
         else:
             (variables[expression], data[expression]) = parse_expression(expression, parent_data)
-    variables = list(set(reduce(operator.add, variables.values())))
+    variables = list(dict.fromkeys(reduce(operator.add, variables.values())))
     data = pd.concat((data.values()), axis=1)
 
     if unscramble:

--- a/niworkflows/tests/test_confounds.py
+++ b/niworkflows/tests/test_confounds.py
@@ -134,6 +134,30 @@ def test_expansion_na_robustness(datadir):
         pd.testing.assert_series_equal(expected_data[col], exp_data[col], check_dtype=False)
 
 
+def test_expansion_column_order_deterministic(datadir):
+    """Column order is deterministic across runs (regression for nipreps/fmriprep#3501)."""
+    model_formula = '(dd1(a + b + c))^^2 + others'
+    expected_columns = [
+        'a',
+        'a_derivative1',
+        'a_power2',
+        'a_derivative1_power2',
+        'b',
+        'b_derivative1',
+        'b_power2',
+        'b_derivative1_power2',
+        'c',
+        'c_derivative1',
+        'c_power2',
+        'c_derivative1_power2',
+        'd',
+        'e',
+        'f',
+    ]
+    exp_data = _expand_test(model_formula, datadir)
+    assert list(exp_data.columns) == expected_columns
+
+
 def test_spikes(datadir):
     """Test outlier flagging"""
     outliers = [1, 1, 0, 0, 1]


### PR DESCRIPTION
Closes nipreps/fmriprep#3501.

## Changes

- `parse_formula`: replace `list(set(reduce(...)))` with `list(dict.fromkeys(reduce(...)))` to preserve insertion order while deduplicating.
- `_expand_shorthand`: build the `others` substitution with an ordered generator over `variables` rather than `set(variables) - set(formula_variables)`.
- `temporal_derivatives` / `exponential_terms`: wrap `set(order) - {0|1}` in `sorted()` so multi-order expansions iterate in ascending order.

## Why

Each of those `set()` iterations depends on Python's hash seed, so the same fMRIPrep run could produce columns in different order between executions. The user reported this in nipreps/fmriprep#3501 with `--skull-strip-fixed-seed --omp-nthreads 1 --random-seed N` set, expecting bit-identical output across runs.

## Testing

Added `test_expansion_column_order_deterministic` asserting the exact expected column order for `(dd1(a + b + c))^^2 + others` against the existing test fixture. Empirically:

- Under the unpatched code, the test fails on all six `PYTHONHASHSEED` values I tried (1, 2, 3, 42, 100, 9999).
- Under the fix, the test passes on all six.
- Existing `test_expansion_*` tests continue to pass (they assert column sets, not order, so they were unaffected).

`ruff check`, `ruff format --check`, and `codespell` pass on both modified files.
