### PR TITLE
Drop bids_filters entries with no matching query

### DIFF
--- a/niworkflows/utils/bids.py
+++ b/niworkflows/utils/bids.py
@@ -271,6 +271,8 @@ def collect_data(
 
     bids_filters = bids_filters or {}
     for acq, entities in bids_filters.items():
+        if acq not in queries:  # filter with no matching query
+            continue
         # BIDS filters will not be able to override subject / session entities
         for entity, param in reserved_entities:
             if param == Query.OPTIONAL:

--- a/niworkflows/utils/tests/test_bids.py
+++ b/niworkflows/utils/tests/test_bids.py
@@ -1,0 +1,24 @@
+"""Tests for :mod:`niworkflows.utils.bids`."""
+
+from ..bids import collect_data
+from ..testing import generate_bids_skeleton
+
+SKELETON = {
+    'dataset_description': {'Name': 'sample', 'BIDSVersion': '1.6.0'},
+    '01': [{'anat': [{'suffix': 'T1w', 'metadata': {'EchoTime': 1}}]}],
+}
+
+
+def test_collect_data_ignores_filter_without_query(tmp_path):
+    """A filter naming a suffix absent from ``queries`` is dropped, not an error."""
+    root = tmp_path / 'bids'
+    generate_bids_skeleton(root, SKELETON)
+
+    subj_data, _ = collect_data(
+        root,
+        '01',
+        bids_validate=False,
+        queries={'t1w': {'datatype': 'anat', 'suffix': 'T1w'}},
+        bids_filters={'pet': {'session': '15'}},
+    )
+    assert len(subj_data['t1w']) == 1


### PR DESCRIPTION
Closes #862.

`collect_data` merges filters with `queries[acq].update(entities)` and never checks that `acq` is a key, so a filter naming a suffix absent from a caller-supplied `queries` raises instead of being ignored:

```python
collect_data(root, '01', bids_validate=False,
             queries={'t1w': {'datatype': 'anat', 'suffix': 'T1w'}},
             bids_filters={'pet': {'session': '15'}})
# KeyError: 'pet'
```

Two-line guard skips those filters. Test added using `generate_bids_skeleton`; it fails without the fix with the same `KeyError`. `pytest niworkflows/utils`: 73 passed, 5 skipped.
